### PR TITLE
#154 Not updating Query list when there is no query data

### DIFF
--- a/src/components/common/QueryTree.js
+++ b/src/components/common/QueryTree.js
@@ -3,14 +3,15 @@ import { TreeSelect } from 'antd';
 import { Alert } from '@mui/material';
 
 const QueryTree = ({ data, onSelectedQuery, queryType, isLoading }) => {
-  const [selectedQuery, setSelectedQuery] = useState(undefined);
-
-  const [showQueryNotSelectedAlert, setShowQueryNotSelectedAlert] = useState(false);
-  const [isDisabled, setIsDisabled] = useState(false);
-  const [placeholder, setPlaceholder] = useState(noData);
   const noData = `No query for ${
     queryType === 'req-test' ? 'Requirement - Test case' : 'Test case - Requirement'
   } available`;
+
+  const [selectedQuery, setSelectedQuery] = useState(undefined);
+  const [showQueryNotSelectedAlert, setShowQueryNotSelectedAlert] = useState(false);
+  const [isDisabled, setIsDisabled] = useState(false);
+  const [placeholder, setPlaceholder] = useState(noData);
+
   useEffect(() => {
     setIsDisabled(data?.length === 0);
   }, [data]);

--- a/src/components/common/TestContentSelector.js
+++ b/src/components/common/TestContentSelector.js
@@ -58,14 +58,13 @@ const TestContentSelector = ({
   });
 
   useEffect(() => {
-    if (sharedQueries.acquiredTrees) {
-      const { acquiredTrees } = toJS(sharedQueries);
-      setQueryTrees((prev) => ({
-        ...prev,
-        ...(acquiredTrees.reqTestTree && { reqTestTree: [acquiredTrees.reqTestTree] }),
-        ...(acquiredTrees.testReqTree && { testReqTree: [acquiredTrees.testReqTree] }),
-      }));
-    }
+    const { acquiredTrees } = toJS(sharedQueries);
+    acquiredTrees !== null
+      ? setQueryTrees(() => ({
+          reqTestTree: acquiredTrees.reqTestTree ? [acquiredTrees.reqTestTree] : [],
+          testReqTree: acquiredTrees.testReqTree ? [acquiredTrees.testReqTree] : [],
+        }))
+      : setQueryTrees(defaultSelectedQueries);
   }, [sharedQueries.acquiredTrees]);
 
   useEffect(() => {

--- a/src/store/DataStore.js
+++ b/src/store/DataStore.js
@@ -236,7 +236,9 @@ class DocGenDataStore {
       .then((data) => {
         this.setSharedQueries(data);
       })
-      .catch((err) => {})
+      .catch((err) => {
+        console.log(err.message);
+      })
       .finally(() => {
         this.loadingState.sharedQueriesLoadingState = false;
       });
@@ -246,9 +248,8 @@ class DocGenDataStore {
     return this.loadingState;
   }
   //for setting shared queries
-  setSharedQueries(data) {
-    const { reqTestTree, testReqTree } = data;
-    this.sharedQueries.acquiredTrees = { reqTestTree, testReqTree };
+  setSharedQueries(queryData) {
+    this.sharedQueries.acquiredTrees = { ...queryData };
   }
   //for fetching repo list
   fetchGitRepoList() {


### PR DESCRIPTION
- When query tree is empty, the list in the TreeSelect is cleared