### PR TITLE
#297488 - trace column settings UX overhaul + dialog bugs

### DIFF
--- a/src/components/common/guides/STDGuide.jsx
+++ b/src/components/common/guides/STDGuide.jsx
@@ -126,8 +126,8 @@ const STDGuide = () => {
             </ListItem>
             <ListItem sx={{ pl: 6 }}>
               <ListItemText
-                primary='Include Common Columns'
-                secondary='Choose how to handle duplicate columns between query sources.'
+                primary='Column Settings'
+                secondary='Rename, show/hide, or reorder columns independently for each query (Req → TC and TC → Req). Settings are per-query and per-side (Requirement / Test Case). Columns are refreshed from ADO each time you select a query.'
               />
             </ListItem>
           </List>

--- a/src/components/common/guides/STPGuide.jsx
+++ b/src/components/common/guides/STPGuide.jsx
@@ -131,8 +131,8 @@ const STPGuide = () => {
             </ListItem>
             <ListItem sx={{ pl: 6 }}>
               <ListItemText
-                primary='Include Common Columns'
-                secondary='Choose how to handle duplicate columns between query sources.'
+                primary='Column Settings'
+                secondary='Rename, show/hide, or reorder columns independently for each query (Req → TC and TC → Req). Settings are per-query and per-side (Requirement / Test Case). Columns are refreshed from ADO each time you select a query.'
               />
             </ListItem>
           </List>

--- a/src/components/common/guides/STRGuide.jsx
+++ b/src/components/common/guides/STRGuide.jsx
@@ -75,6 +75,12 @@ const STRGuide = () => {
                 secondary='Append requirement coverage based on your trace config.'
               />
             </ListItem>
+            <ListItem sx={{ pl: 6 }}>
+              <ListItemText
+                primary='Column Settings'
+                secondary='Rename, show/hide, or reorder columns in the coverage table. Columns are refreshed from ADO each time you select a query.'
+              />
+            </ListItem>
           </List>
         </Collapse>
 

--- a/src/components/common/table/TestContentSelector.jsx
+++ b/src/components/common/table/TestContentSelector.jsx
@@ -41,7 +41,7 @@ const defaultSelectedQueries = {
   fieldDisplayMapping: {},
   fieldVisibility: {},
   fieldOrder: {},
-  columnMetadata: null,
+  columnMetadata: {},
 };
 
 const defaultLinkedMomRequest = {
@@ -232,6 +232,16 @@ const TestContentSelector = observer(
       (incoming) => {
         if (!incoming || !store.sharedQueries) return;
         const validated = { ...incoming };
+        // Sanitize legacy type-keyed maps (pre-per-query-column-settings shape)
+        const sanitizeFieldMap = (raw) => {
+          if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return {};
+          if ('Requirement' in raw || 'Test Case' in raw) return {};
+          return raw;
+        };
+        validated.fieldDisplayMapping = sanitizeFieldMap(incoming.fieldDisplayMapping);
+        validated.fieldVisibility = sanitizeFieldMap(incoming.fieldVisibility);
+        validated.fieldOrder = sanitizeFieldMap(incoming.fieldOrder);
+        validated.columnMetadata = {}; // always re-fetched; never trust persisted metadata
         if (incoming.reqTestQuery && store.sharedQueries?.acquiredTrees?.reqTestTree) {
           const validReqTestQuery = validateQuery(
             [store.sharedQueries.acquiredTrees.reqTestTree],
@@ -324,7 +334,7 @@ const TestContentSelector = observer(
           savedDataRef.current = dataToSave;
           logger.debug(`[${selectorTag}] applySavedData: applied`);
         } catch (error) {
-          console.error('Error loading saved data:', error);
+          logger.error('Error loading saved data:', error);
           toast.error(`Error loading favorite data: ${error.message}`);
         }
       },
@@ -502,9 +512,6 @@ const TestContentSelector = observer(
           traceAnalysisRequest.traceAnalysisMode === 'linkedRequirement'
             ? 'Requirements from linked trace'
             : 'Requirements from queries',
-          traceAnalysisRequest.includeCommonColumnsMode !== 'both'
-            ? `Common columns: ${traceAnalysisRequest.includeCommonColumnsMode}`
-            : null,
         ].filter(Boolean)
       : undefined;
 
@@ -613,7 +620,7 @@ const TestContentSelector = observer(
                   settings={traceAnalysisSummary || []}
                   emptyMessage='Pull requirements traceability based on linked items or queries.'
                   actions={
-                    <Stack direction='row' spacing={1}>
+                    <Box sx={{ display: 'flex', gap: 0.5, border: '1px solid', borderColor: 'divider', borderRadius: 1, p: 0.5 }}>
                       <TraceAnalysisDialog
                         store={store}
                         sharedQueries={store.sharedQueries}
@@ -636,9 +643,9 @@ const TestContentSelector = observer(
                         traceAnalysisMode={traceAnalysisRequest.traceAnalysisMode}
                         reqTestQuery={traceAnalysisRequest.reqTestQuery}
                         testReqQuery={traceAnalysisRequest.testReqQuery}
-                        columnMetadata={traceAnalysisRequest.columnMetadata}
+                        columnMetadata={traceAnalysisRequest.columnMetadata || {}}
                       />
-                    </Stack>
+                    </Box>
                   }
                 />
               </Stack>

--- a/src/components/dialogs/DetailedStepsSettingsDialog.jsx
+++ b/src/components/dialogs/DetailedStepsSettingsDialog.jsx
@@ -5,15 +5,25 @@ import {
   Dialog,
   DialogContent,
   DialogTitle,
+  Divider,
   FormControlLabel,
   FormLabel,
   Grid,
+  IconButton,
+  List,
+  ListItem,
+  ListItemText,
+  Popover,
   Radio,
   RadioGroup,
+  Stack,
+  Tooltip,
   Button,
   DialogActions,
+  Typography,
 } from '@mui/material';
 import StairsIcon from '@mui/icons-material/Stairs';
+import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
 import React, { useState, useEffect } from 'react';
 import QueryTree from '../common/QueryTree';
 import OverlayLoader from '../common/OverlayLoader';
@@ -26,8 +36,9 @@ const DetailedStepsSettingsDialog = ({
   onStepExecutionStateChange,
 }) => {
   const [openDialog, setOpenDialog] = useState(false);
+  const [infoAnchor, setInfoAnchor] = useState(null);
   const [stepExecutionState, setStepExecutionState] = useState(prevStepExecution);
-  useState(() => {
+  useEffect(() => {
     if (prevStepExecution) setStepExecutionState(prevStepExecution);
   }, [prevStepExecution]);
 
@@ -158,29 +169,27 @@ const DetailedStepsSettingsDialog = ({
 
   const linkedRequirementToggles = (
     <Box sx={{ display: 'flex', flexDirection: 'column', ml: 3 }}>
-      <div>
-        <FormControlLabel
-          label='Include Customer Id'
-          control={
-            <Checkbox
-              label='Include Customer Id'
-              checked={stepExecutionState.generateRequirements.includeCustomerId}
-              onChange={(event, checked) => {
-                setStepExecutionState((prev) => ({
-                  ...prev,
-                  generateRequirements: { ...prev.generateRequirements, includeCustomerId: checked },
-                }));
-              }}
-            />
-          }
-        />
-      </div>
+      {stepExecutionState.generateRequirements.requirementInclusionMode !== 'query' && (
+        <div>
+          <FormControlLabel
+            label='Include Customer Id'
+            control={
+              <Checkbox
+                checked={stepExecutionState.generateRequirements.includeCustomerId}
+                onChange={(event, checked) => {
+                  setStepExecutionState((prev) => ({
+                    ...prev,
+                    generateRequirements: { ...prev.generateRequirements, includeCustomerId: checked },
+                  }));
+                }}
+              />
+            }
+          />
+        </div>
+      )}
 
       <div>
-        <FormLabel
-          id='linked-requirement-buttons-group'
-          label='Requirement Type'
-        >
+        <FormLabel id='linked-requirement-buttons-group'>
           Covered Requirements Based On:
         </FormLabel>
         <RadioGroup
@@ -204,40 +213,12 @@ const DetailedStepsSettingsDialog = ({
             disabled={
               store.fetchLoadingState().sharedQueriesLoadingState ||
               queryTrees.testReqTree === null ||
-              !queryTrees.testReqTree.length > 0
+              !(queryTrees.testReqTree?.length > 0)
             }
           />
         </RadioGroup>
       </div>
 
-      <Box sx={{ mt: 1 }}>
-        <FieldDisplayMappingDialog
-          fieldDisplayMapping={stepExecutionState.generateRequirements.fieldDisplayMapping || {}}
-          onMappingChange={(mapping) =>
-            setStepExecutionState((prev) => ({
-              ...prev,
-              generateRequirements: { ...prev.generateRequirements, fieldDisplayMapping: mapping },
-            }))
-          }
-          fieldVisibility={stepExecutionState.generateRequirements.fieldVisibility || {}}
-          onVisibilityChange={(visibility) =>
-            setStepExecutionState((prev) => ({
-              ...prev,
-              generateRequirements: { ...prev.generateRequirements, fieldVisibility: visibility },
-            }))
-          }
-          fieldOrder={stepExecutionState.generateRequirements.fieldOrder || {}}
-          onOrderChange={(order) =>
-            setStepExecutionState((prev) => ({
-              ...prev,
-              generateRequirements: { ...prev.generateRequirements, fieldOrder: order },
-            }))
-          }
-          traceAnalysisMode={stepExecutionState.generateRequirements.requirementInclusionMode}
-          testReqQuery={stepExecutionState.generateRequirements.testReqQuery}
-          columnMetadata={stepExecutionState.generateRequirements.columnMetadata}
-        />
-      </Box>
     </Box>
   );
 
@@ -263,6 +244,7 @@ const DetailedStepsSettingsDialog = ({
           }
         />
       </div>
+      <Divider sx={{ my: 1 }} />
       <div>
         <FormControlLabel
           label='Generate Attachments'
@@ -281,6 +263,7 @@ const DetailedStepsSettingsDialog = ({
         {stepExecutionState.generateAttachments.isEnabled && attachmentTypeElements('execution')}
       </div>
 
+      <Divider sx={{ my: 1 }} />
       <div>
         <FormControlLabel
           label='Generate Covered Requirements'
@@ -306,13 +289,44 @@ const DetailedStepsSettingsDialog = ({
           timeout='auto'
           unmountOnExit
         >
-          <QueryTree
-            data={queryTrees.testReqTree}
-            prevSelectedQuery={stepExecutionState.generateRequirements.testReqQuery}
-            onSelectedQuery={onQuerySelected}
-            queryType={'test-req'}
-            isLoading={store.fetchLoadingState().sharedQueriesLoadingState}
-          />
+          <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 0.5 }}>
+            <Box sx={{ flex: 1, minWidth: 0 }}>
+              <QueryTree
+                data={queryTrees.testReqTree}
+                prevSelectedQuery={stepExecutionState.generateRequirements.testReqQuery}
+                onSelectedQuery={onQuerySelected}
+                queryType={'test-req'}
+                isLoading={store.fetchLoadingState().sharedQueriesLoadingState}
+              />
+            </Box>
+            <FieldDisplayMappingDialog
+              iconOnly
+              fieldDisplayMapping={stepExecutionState.generateRequirements.fieldDisplayMapping || {}}
+              onMappingChange={(mapping) =>
+                setStepExecutionState((prev) => ({
+                  ...prev,
+                  generateRequirements: { ...prev.generateRequirements, fieldDisplayMapping: mapping },
+                }))
+              }
+              fieldVisibility={stepExecutionState.generateRequirements.fieldVisibility || {}}
+              onVisibilityChange={(visibility) =>
+                setStepExecutionState((prev) => ({
+                  ...prev,
+                  generateRequirements: { ...prev.generateRequirements, fieldVisibility: visibility },
+                }))
+              }
+              fieldOrder={stepExecutionState.generateRequirements.fieldOrder || {}}
+              onOrderChange={(order) =>
+                setStepExecutionState((prev) => ({
+                  ...prev,
+                  generateRequirements: { ...prev.generateRequirements, fieldOrder: order },
+                }))
+              }
+              traceAnalysisMode={stepExecutionState.generateRequirements.requirementInclusionMode}
+              testReqQuery={stepExecutionState.generateRequirements.testReqQuery}
+              columnMetadata={stepExecutionState.generateRequirements.columnMetadata}
+            />
+          </Box>
         </Collapse>
       </div>
     </Box>
@@ -358,12 +372,75 @@ const DetailedStepsSettingsDialog = ({
         open={openDialog}
         onClose={handleClose}
         disablePortal={false}
-        sx={{
-          '& .MuiDialog-paper': { overflow: 'visible' },
-        }}
       >
-        <DialogTitle>Step Execution Settings</DialogTitle>
-        <DialogContent aria-busy={store.fetchLoadingState().sharedQueriesLoadingState || undefined}>
+        <DialogTitle sx={{ pb: 0.5 }}>
+          <Stack direction='row' alignItems='center' spacing={0.5}>
+            <Typography variant='h6' component='div'>Step Execution Settings</Typography>
+            <Tooltip title='How to use' arrow>
+              <IconButton size='small' onClick={(e) => setInfoAnchor(e.currentTarget)} sx={{ color: 'text.disabled', '&:hover': { color: 'text.secondary' } }}>
+                <InfoOutlinedIcon sx={{ fontSize: 17 }} />
+              </IconButton>
+            </Tooltip>
+          </Stack>
+          <Popover
+            open={Boolean(infoAnchor)}
+            anchorEl={infoAnchor}
+            onClose={() => setInfoAnchor(null)}
+            anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
+            transformOrigin={{ vertical: 'top', horizontal: 'left' }}
+            PaperProps={{ sx: { maxWidth: 340, borderRadius: 2, p: 0 } }}
+          >
+            <Box sx={{ px: 2, pt: 1.5, pb: 0.5 }}>
+              <Typography variant='subtitle2' sx={{ fontWeight: 700 }}>Step Execution Settings Guide</Typography>
+            </Box>
+            <List dense disablePadding sx={{ px: 1, pb: 1 }}>
+              <ListItem sx={{ alignItems: 'flex-start', py: 0.5 }}>
+                <ListItemText
+                  primary='Flat Test Cases of a Single Suite'
+                  secondary='Merge test cases from a single suite into one flat table instead of grouped by suite.'
+                  primaryTypographyProps={{ variant: 'body2', fontWeight: 600 }}
+                  secondaryTypographyProps={{ variant: 'caption' }}
+                />
+              </ListItem>
+              <ListItem sx={{ alignItems: 'flex-start', py: 0.5 }}>
+                <ListItemText
+                  primary='Generate Attachments'
+                  secondary='Embed step-level and test-level attachments in the document. Choose As Embedded (inline) or As Link (packaged ZIP). Evidence By controls whether run-level, plan-level, or both attachment types are included.'
+                  primaryTypographyProps={{ variant: 'body2', fontWeight: 600 }}
+                  secondaryTypographyProps={{ variant: 'caption' }}
+                />
+              </ListItem>
+              <ListItem sx={{ alignItems: 'flex-start', py: 0.5 }}>
+                <ListItemText
+                  primary='Generate Covered Requirements'
+                  secondary='Add a requirements coverage table per test case. Use Linked Requirements for ADO-linked items, or Queries to build the table from a TC → Req query.'
+                  primaryTypographyProps={{ variant: 'body2', fontWeight: 600 }}
+                  secondaryTypographyProps={{ variant: 'caption' }}
+                />
+              </ListItem>
+              <ListItem sx={{ alignItems: 'flex-start', py: 0.5 }}>
+                <ListItemText
+                  primary='Include Customer Id'
+                  secondary='Adds the Customer ID column to the requirements table. Available in linked requirements mode only.'
+                  primaryTypographyProps={{ variant: 'body2', fontWeight: 600 }}
+                  secondaryTypographyProps={{ variant: 'caption' }}
+                />
+              </ListItem>
+              <ListItem sx={{ alignItems: 'flex-start', py: 0.5 }}>
+                <ListItemText
+                  primary='Column Settings (icon button)'
+                  secondary='Appears next to the query selector after a TC → Req query is chosen. Rename, show/hide, or reorder columns in the requirements table.'
+                  primaryTypographyProps={{ variant: 'body2', fontWeight: 600 }}
+                  secondaryTypographyProps={{ variant: 'caption' }}
+                />
+              </ListItem>
+            </List>
+          </Popover>
+        </DialogTitle>
+        <DialogContent
+          aria-busy={store.fetchLoadingState().sharedQueriesLoadingState || undefined}
+          sx={{ overflow: 'visible' }}
+        >
           <Box sx={{ position: 'relative' }}>
             <OverlayLoader
               loading={store.fetchLoadingState().sharedQueriesLoadingState}

--- a/src/components/dialogs/FieldDisplayMappingDialog.jsx
+++ b/src/components/dialogs/FieldDisplayMappingDialog.jsx
@@ -1,4 +1,5 @@
 import {
+  Alert,
   Box,
   Button,
   Chip,
@@ -7,6 +8,10 @@ import {
   DialogTitle,
   Divider,
   IconButton,
+  List,
+  ListItem,
+  ListItemText,
+  Popover,
   TextField,
   ToggleButton,
   ToggleButtonGroup,
@@ -42,7 +47,17 @@ import { CSS } from '@dnd-kit/utilities';
 import { COLOR_REQ, COLOR_TEST_CASE } from '../../constants/traceColors';
 
 const TYPE_COLORS = { Requirement: COLOR_REQ, 'Test Case': COLOR_TEST_CASE };
+// TODO: theme token — no equivalent in tokens.js; replace when palette is extended
 const TYPE_COLORS_SELECTED = { Requirement: '#b8cfe6', 'Test Case': '#cdc5df' };
+
+function TabBadge({ type, count }) {
+  if (!count) return null;
+  return (
+    <Box component='span' sx={{ ml: 0.75, display: 'inline-flex', alignItems: 'center', justifyContent: 'center', bgcolor: TYPE_COLORS_SELECTED[type], borderRadius: '10px', px: 0.75, minWidth: 18, height: 18, fontSize: '0.68rem', fontWeight: 700, lineHeight: 1, color: 'text.primary' }}>
+      {count}
+    </Box>
+  );
+}
 
 // ADO referenceNames + linked-mode pseudo-keys that are always shown and never dragged
 const ALWAYS_VISIBLE_REFS = new Set(['System.Id', 'System.Title', 'Req ID', 'Test Case ID', 'Title']);
@@ -54,36 +69,50 @@ const LINKED_REQ_COLUMNS = {
   'Test Case': [],
 };
 
+// Returns { 'req-test': { Requirement, 'Test Case' }, 'test-req': { Requirement, 'Test Case' } }
 function deriveFieldList(traceAnalysisMode, reqTestQuery, testReqQuery, columnMetadata) {
-  if (traceAnalysisMode === 'linkedRequirement') return LINKED_REQ_COLUMNS;
-  if (traceAnalysisMode !== 'query') return { Requirement: [], 'Test Case': [] };
-
-  // When backend-verified per-side metadata is available (null = not yet fetched), use it.
-  // This distinguishes "fetch completed, side has zero configurable columns" from "not fetched yet".
-  if (columnMetadata !== null && columnMetadata !== undefined) {
-    const filterMeta = (cols) =>
-      (cols || []).filter(
-        (c) => c?.referenceName && !EXCLUDED_FIELD_REFS.has(c.referenceName) && !ALWAYS_VISIBLE_REFS.has(c.referenceName)
-      );
-    return {
-      Requirement: filterMeta(columnMetadata.Requirement),
-      'Test Case': filterMeta(columnMetadata['Test Case']),
-    };
+  if (traceAnalysisMode === 'linkedRequirement') {
+    return { 'req-test': LINKED_REQ_COLUMNS, 'test-req': LINKED_REQ_COLUMNS };
+  }
+  if (traceAnalysisMode !== 'query') {
+    return { 'req-test': { Requirement: [], 'Test Case': [] }, 'test-req': { Requirement: [], 'Test Case': [] } };
   }
 
-  // Fallback: merge both queries' declared columns for both sides (legacy / loading state)
-  const seen = new Set();
-  const merged = [];
-  for (const cols of [reqTestQuery?.columns, testReqQuery?.columns].filter(Boolean)) {
-    for (const col of cols) {
+  const filterMeta = (cols) =>
+    (cols || []).filter(
+      (c) => c?.referenceName && !EXCLUDED_FIELD_REFS.has(c.referenceName) && !ALWAYS_VISIBLE_REFS.has(c.referenceName)
+    );
+
+  const fallbackFromQuery = (query) => {
+    const seen = new Set();
+    const cols = [];
+    for (const col of (query?.columns || [])) {
       if (!col?.referenceName || seen.has(col.referenceName)) continue;
       if (EXCLUDED_FIELD_REFS.has(col.referenceName)) continue;
       if (ALWAYS_VISIBLE_REFS.has(col.referenceName)) continue;
       seen.add(col.referenceName);
-      merged.push({ referenceName: col.referenceName, name: col.name });
+      cols.push({ referenceName: col.referenceName, name: col.name });
     }
-  }
-  return { Requirement: merged, 'Test Case': merged };
+    return cols;
+  };
+
+  const resolveQuerySides = (queryKey, query) => {
+    const meta = columnMetadata?.[queryKey];
+    if (meta) {
+      return {
+        Requirement: filterMeta(meta.Requirement),
+        'Test Case': filterMeta(meta['Test Case']),
+      };
+    }
+    // Fallback: use this query's own declared columns for both sides (loading / no metadata)
+    const fb = fallbackFromQuery(query);
+    return { Requirement: fb, 'Test Case': fb };
+  };
+
+  return {
+    'req-test': resolveQuerySides('req-test', reqTestQuery),
+    'test-req': resolveQuerySides('test-req', testReqQuery),
+  };
 }
 
 function countMods(mappingByType, visibilityByType, type) {
@@ -200,138 +229,213 @@ const FieldDisplayMappingDialog = ({
   traceAnalysisMode = 'none',
   reqTestQuery = null,
   testReqQuery = null,
-  columnMetadata = null, // null = not yet fetched; { Requirement:[], 'Test Case':[] } = fetched (may be empty)
+  columnMetadata = {}, // {} = not yet fetched / loading; { 'req-test': { Requirement, 'Test Case' }, 'test-req': { ... } } = fetched per query
+  iconOnly = false,
 }) => {
   const [open, setOpen] = useState(false);
+  const [infoAnchor, setInfoAnchor] = useState(null);
   const [workingMapping, setWorkingMapping] = useState({});
   const [workingVisibility, setWorkingVisibility] = useState({});
   const [workingOrder, setWorkingOrder] = useState({});
   const [selectedType, setSelectedType] = useState('Requirement');
+  const [selectedQuery, setSelectedQuery] = useState(() => reqTestQuery ? 'req-test' : 'test-req');
+  useEffect(() => {
+    if (!open) return;
+    setSelectedQuery(reqTestQuery ? 'req-test' : 'test-req');
+  }, [open]); // eslint-disable-line react-hooks/exhaustive-deps
   const [searchText, setSearchText] = useState('');
 
-  const fieldsByType = useMemo(
+  // Auto-correct selectedQuery if the previously selected query is no longer available
+  useEffect(() => {
+    if (selectedQuery === 'req-test' && !reqTestQuery && testReqQuery) setSelectedQuery('test-req');
+    if (selectedQuery === 'test-req' && !testReqQuery && reqTestQuery) setSelectedQuery('req-test');
+  }, [reqTestQuery, testReqQuery]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const fieldsByQuery = useMemo(
     () => deriveFieldList(traceAnalysisMode, reqTestQuery, testReqQuery, columnMetadata),
     [traceAnalysisMode, reqTestQuery, testReqQuery, columnMetadata]
   );
+  const fieldsByType = fieldsByQuery[selectedQuery] || { Requirement: [], 'Test Case': [] };
 
   useEffect(() => {
     if (!open) return;
     setWorkingMapping({ ...fieldDisplayMapping });
     setWorkingVisibility({ ...fieldVisibility });
 
-    // Initialize order per type: respect saved order, append any new fields not yet ordered
+    // Initialize order per query per side: respect saved order, append new fields
     const initOrder = {};
-    for (const [type, fields] of Object.entries(fieldsByType)) {
-      const existing = fieldOrder[type] || [];
-      const knownRefs = new Set(existing);
-      initOrder[type] = [
-        ...existing.filter((ref) => fields.some((f) => f.referenceName === ref)),
-        ...fields.filter((f) => !knownRefs.has(f.referenceName)).map((f) => f.referenceName),
-      ];
+    for (const [queryKey, sides] of Object.entries(fieldsByQuery)) {
+      initOrder[queryKey] = {};
+      for (const [side, fields] of Object.entries(sides)) {
+        const existing = fieldOrder?.[queryKey]?.[side] || [];
+        const knownRefs = new Set(existing);
+        initOrder[queryKey][side] = [
+          ...existing.filter((ref) => fields.some((f) => f.referenceName === ref)),
+          ...fields.filter((f) => !knownRefs.has(f.referenceName)).map((f) => f.referenceName),
+        ];
+      }
     }
     setWorkingOrder(initOrder);
   }, [open]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  // Ordered visible fields for current tab
+  // Augment workingOrder with fields that arrived after dialog opened (e.g. late columnMetadata fetch).
+  // Append-only: never resets mapping/visibility; identity-stable when nothing changes.
+  useEffect(() => {
+    if (!open) return;
+    setWorkingOrder((prev) => {
+      let changed = false;
+      const next = { ...prev };
+      for (const [queryKey, sides] of Object.entries(fieldsByQuery)) {
+        const nextSides = { ...(next[queryKey] || {}) };
+        for (const [side, fields] of Object.entries(sides)) {
+          const existing = nextSides[side] || [];
+          const known = new Set(existing);
+          const additions = fields
+            .filter((f) => !known.has(f.referenceName))
+            .map((f) => f.referenceName);
+          if (additions.length) {
+            nextSides[side] = [...existing, ...additions];
+            changed = true;
+          }
+        }
+        next[queryKey] = nextSides;
+      }
+      return changed ? next : prev;
+    });
+  }, [open, fieldsByQuery]);
+
+  // Ordered visible fields for current query + side tab
   const visibleFields = useMemo(() => {
     const allFields = fieldsByType[selectedType] || [];
-    const order = workingOrder[selectedType] || [];
+    const order = workingOrder[selectedQuery]?.[selectedType] || [];
 
     // Sort by order, unknown refs appended
     const byRef = Object.fromEntries(allFields.map((f) => [f.referenceName, f]));
+    const orderSet = new Set(order);
     const orderedRefs = [
       ...order.filter((ref) => byRef[ref]),
-      ...allFields.filter((f) => !order.includes(f.referenceName)).map((f) => f.referenceName),
+      ...allFields.filter((f) => !orderSet.has(f.referenceName)).map((f) => f.referenceName),
     ];
     const sorted = orderedRefs.map((ref) => byRef[ref]).filter(Boolean);
 
     if (!searchText.trim()) return sorted;
     const lower = searchText.toLowerCase();
     return sorted.filter((f) => f.name.toLowerCase().includes(lower));
-  }, [fieldsByType, selectedType, searchText, workingOrder]);
+  }, [fieldsByType, selectedType, selectedQuery, searchText, workingOrder]);
 
-  const modReq = useMemo(() => countMods(workingMapping, workingVisibility, 'Requirement'), [workingMapping, workingVisibility]);
-  const modTest = useMemo(() => countMods(workingMapping, workingVisibility, 'Test Case'), [workingMapping, workingVisibility]);
+  // Per-side counts for the active query (used for in-dialog badges and reset logic)
+  const modReq = useMemo(() => countMods(workingMapping[selectedQuery] || {}, workingVisibility[selectedQuery] || {}, 'Requirement'), [workingMapping, workingVisibility, selectedQuery]);
+  const modTest = useMemo(() => countMods(workingMapping[selectedQuery] || {}, workingVisibility[selectedQuery] || {}, 'Test Case'), [workingMapping, workingVisibility, selectedQuery]);
   const modCountByType = { Requirement: modReq, 'Test Case': modTest };
-  const totalCount = modReq + modTest;
+  // Total across all queries for the trigger button
+  const totalCount = useMemo(() => {
+    let n = 0;
+    for (const qKey of ['req-test', 'test-req']) {
+      n += countMods(workingMapping[qKey] || {}, workingVisibility[qKey] || {}, 'Requirement');
+      n += countMods(workingMapping[qKey] || {}, workingVisibility[qKey] || {}, 'Test Case');
+    }
+    return n;
+  }, [workingMapping, workingVisibility]);
+  // Per-direction total for the direction pills
+  const modByDirection = useMemo(() => {
+    const forKey = (key) =>
+      countMods(workingMapping[key] || {}, workingVisibility[key] || {}, 'Requirement') +
+      countMods(workingMapping[key] || {}, workingVisibility[key] || {}, 'Test Case');
+    return { 'req-test': forKey('req-test'), 'test-req': forKey('test-req') };
+  }, [workingMapping, workingVisibility]);
 
   const handleFieldOverride = (referenceName, value) => {
     setWorkingMapping((prev) => {
-      const typeMap = { ...(prev[selectedType] || {}) };
+      const querySlice = { ...(prev[selectedQuery] || {}) };
+      const typeMap = { ...(querySlice[selectedType] || {}) };
       if (value.trim()) typeMap[referenceName] = value;
       else delete typeMap[referenceName];
-      return { ...prev, [selectedType]: typeMap };
+      querySlice[selectedType] = typeMap;
+      return { ...prev, [selectedQuery]: querySlice };
     });
   };
 
   const handleToggleVisibility = (referenceName) => {
     if (ALWAYS_VISIBLE_REFS.has(referenceName)) return;
     setWorkingVisibility((prev) => {
-      const typeMap = { ...(prev[selectedType] || {}) };
+      const querySlice = { ...(prev[selectedQuery] || {}) };
+      const typeMap = { ...(querySlice[selectedType] || {}) };
       if (typeMap[referenceName] === false) delete typeMap[referenceName];
       else typeMap[referenceName] = false;
-      return { ...prev, [selectedType]: typeMap };
+      querySlice[selectedType] = typeMap;
+      return { ...prev, [selectedQuery]: querySlice };
     });
   };
 
   const allHidden =
     visibleFields.length > 0 &&
-    visibleFields.every((f) => workingVisibility[selectedType]?.[f.referenceName] === false);
+    visibleFields.every((f) => workingVisibility[selectedQuery]?.[selectedType]?.[f.referenceName] === false);
 
   const handleToggleAll = () => {
     setWorkingVisibility((prev) => {
-      const typeMap = { ...(prev[selectedType] || {}) };
+      const querySlice = { ...(prev[selectedQuery] || {}) };
+      const typeMap = { ...(querySlice[selectedType] || {}) };
       if (allHidden) visibleFields.forEach((f) => delete typeMap[f.referenceName]);
       else visibleFields.forEach((f) => { typeMap[f.referenceName] = false; });
-      return { ...prev, [selectedType]: typeMap };
+      querySlice[selectedType] = typeMap;
+      return { ...prev, [selectedQuery]: querySlice };
     });
   };
 
   const handleClear = () => {
-    setWorkingMapping((prev) => { const n = { ...prev }; delete n[selectedType]; return n; });
-    setWorkingVisibility((prev) => { const n = { ...prev }; delete n[selectedType]; return n; });
+    setWorkingMapping((prev) => {
+      const q = { ...(prev[selectedQuery] || {}) };
+      delete q[selectedType];
+      return { ...prev, [selectedQuery]: q };
+    });
+    setWorkingVisibility((prev) => {
+      const q = { ...(prev[selectedQuery] || {}) };
+      delete q[selectedType];
+      return { ...prev, [selectedQuery]: q };
+    });
     setWorkingOrder((prev) => {
       const base = fieldsByType[selectedType] || [];
-      return { ...prev, [selectedType]: base.map((f) => f.referenceName) };
+      const q = { ...(prev[selectedQuery] || {}) };
+      q[selectedType] = base.map((f) => f.referenceName);
+      return { ...prev, [selectedQuery]: q };
     });
   };
 
   const handleDragEnd = ({ active, over }) => {
     if (!over || active.id === over.id) return;
     setWorkingOrder((prev) => {
-      const items = prev[selectedType] || visibleFields.map((f) => f.referenceName);
+      const q = { ...(prev[selectedQuery] || {}) };
+      const items = q[selectedType] || visibleFields.map((f) => f.referenceName);
       const oldIdx = items.indexOf(String(active.id));
       const newIdx = items.indexOf(String(over.id));
       if (oldIdx === -1 || newIdx === -1) return prev;
-      return { ...prev, [selectedType]: arrayMove(items, oldIdx, newIdx) };
+      q[selectedType] = arrayMove(items, oldIdx, newIdx);
+      return { ...prev, [selectedQuery]: q };
     });
   };
 
   const handleClose = () => {
-    const clean = (src) => Object.fromEntries(Object.entries(src).filter(([, v]) => v && Object.keys(v).length > 0));
-    onMappingChange(clean(workingMapping));
-    if (onVisibilityChange) onVisibilityChange(clean(workingVisibility));
+    const cleanSides = (sides) =>
+      Object.fromEntries(Object.entries(sides || {}).filter(([, v]) => v && Object.keys(v).length > 0));
+    const cleanQueries = (src) =>
+      Object.fromEntries(
+        Object.entries(src || {})
+          .map(([qKey, sides]) => [qKey, cleanSides(sides)])
+          .filter(([, sides]) => Object.keys(sides).length > 0)
+      );
+    onMappingChange(cleanQueries(workingMapping));
+    if (onVisibilityChange) onVisibilityChange(cleanQueries(workingVisibility));
     if (onOrderChange) onOrderChange({ ...workingOrder });
     setOpen(false);
   };
 
-  const isDisabled = traceAnalysisMode === 'none';
+  const isDisabled = traceAnalysisMode === 'none' || (iconOnly && !testReqQuery);
   const hasMappings = modCountByType[selectedType] > 0;
-  const renamedCount = Object.keys(workingMapping[selectedType] || {}).length;
-  const hiddenCount = Object.values(workingVisibility[selectedType] || {}).filter((v) => v === false).length;
+  const renamedCount = Object.keys(workingMapping[selectedQuery]?.[selectedType] || {}).length;
+  const hiddenCount = Object.values(workingVisibility[selectedQuery]?.[selectedType] || {}).filter((v) => v === false).length;
   const statusParts = [];
   if (renamedCount > 0) statusParts.push(`${renamedCount} renamed`);
   if (hiddenCount > 0) statusParts.push(`${hiddenCount} hidden`);
-
-  const TabBadge = ({ type }) => {
-    const count = modCountByType[type];
-    if (!count) return null;
-    return (
-      <Box component='span' sx={{ ml: 0.75, display: 'inline-flex', alignItems: 'center', justifyContent: 'center', bgcolor: TYPE_COLORS_SELECTED[type], borderRadius: '10px', px: 0.75, minWidth: 18, height: 18, fontSize: '0.68rem', fontWeight: 700, lineHeight: 1, color: 'text.primary' }}>
-        {count}
-      </Box>
-    );
-  };
 
   const typeColor = TYPE_COLORS[selectedType];
 
@@ -339,44 +443,205 @@ const FieldDisplayMappingDialog = ({
 
   return (
     <>
-      <Tooltip title={isDisabled ? 'Enable trace analysis first' : 'Configure which columns appear and how they are labelled in the trace tables'}>
-        <span>
-          <Button
-            variant='outlined'
-            color='secondary'
-            onClick={() => setOpen(true)}
-            disabled={isDisabled}
-            endIcon={
-              totalCount > 0 ? (
-                <Box sx={{ display: 'flex', gap: 0.5 }}>
-                  {modReq > 0 && (
-                    <Chip label={`Req: ${modReq}`} size='small' sx={{ height: 20, bgcolor: TYPE_COLORS_SELECTED['Requirement'], color: 'text.primary', fontWeight: 700, fontSize: '0.68rem', '& .MuiChip-label': { px: 0.75 } }} />
-                  )}
-                  {modTest > 0 && (
-                    <Chip label={`TC: ${modTest}`} size='small' sx={{ height: 20, bgcolor: TYPE_COLORS_SELECTED['Test Case'], color: 'text.primary', fontWeight: 700, fontSize: '0.68rem', '& .MuiChip-label': { px: 0.75 } }} />
-                  )}
+      {iconOnly ? (
+        <Tooltip title={isDisabled ? 'Select a query first' : 'Column Settings'}>
+          <span>
+            <IconButton
+              onClick={() => setOpen(true)}
+              disabled={isDisabled}
+              color='secondary'
+              size='small'
+              sx={{ position: 'relative', mt: 0.5 }}
+            >
+              <EditNoteIcon />
+              {totalCount > 0 && (
+                <Box sx={{ position: 'absolute', top: 2, right: 2, width: 14, height: 14, bgcolor: 'primary.main', borderRadius: '50%', display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: '0.6rem', fontWeight: 700, color: '#fff', pointerEvents: 'none' }}>
+                  {totalCount}
                 </Box>
-              ) : (
-                <EditNoteIcon />
-              )
-            }
-            sx={{ width: '100%', whiteSpace: 'nowrap' }}
-          >
-            Column Settings
-          </Button>
-        </span>
-      </Tooltip>
+              )}
+            </IconButton>
+          </span>
+        </Tooltip>
+      ) : (
+        <Tooltip title={
+          traceAnalysisMode === 'none'
+            ? 'Enable trace analysis first'
+            : traceAnalysisMode === 'linkedRequirement'
+            ? 'Configure linked requirement column display'
+            : 'Configure columns for both trace directions — Req → TC and TC → Req settings are independent'
+        }>
+          <span>
+            <Button
+              variant='outlined'
+              color='secondary'
+              onClick={() => setOpen(true)}
+              disabled={isDisabled}
+              endIcon={
+                totalCount > 0 ? (
+                  <Chip label={totalCount} size='small' sx={{ height: 20, bgcolor: 'primary.main', color: '#fff', fontWeight: 700, fontSize: '0.68rem', '& .MuiChip-label': { px: 0.75 } }} />
+                ) : (
+                  <EditNoteIcon />
+                )
+              }
+              sx={{ width: '100%', whiteSpace: 'nowrap' }}
+            >
+              Column Settings
+            </Button>
+          </span>
+        </Tooltip>
+      )}
 
       <Dialog open={open} onClose={handleClose} maxWidth='sm' fullWidth PaperProps={{ sx: { borderRadius: 2, minWidth: 480 } }}>
         <DialogTitle sx={{ pb: 0.5, borderBottom: '1px solid', borderColor: 'divider' }}>
           <Stack direction='row' alignItems='flex-start' justifyContent='space-between'>
-            <Box>
-              <Typography variant='h6' component='div' sx={{ lineHeight: 1.3 }}>Column Settings</Typography>
-              <Typography variant='caption' color='text.secondary'>Show/hide, rename, or reorder columns in the generated trace tables</Typography>
+            <Box sx={{ minWidth: 0, flex: 1 }}>
+              <Stack direction='row' alignItems='center' spacing={0.5}>
+                <Typography variant='h6' component='div' sx={{ lineHeight: 1.3 }}>Column Settings</Typography>
+                <Tooltip title='How to use' arrow>
+                  <IconButton size='small' onClick={(e) => setInfoAnchor(e.currentTarget)} sx={{ color: 'text.disabled', '&:hover': { color: 'text.secondary' } }}>
+                    <InfoOutlinedIcon sx={{ fontSize: 17 }} />
+                  </IconButton>
+                </Tooltip>
+              </Stack>
+              <Popover
+                open={Boolean(infoAnchor)}
+                anchorEl={infoAnchor}
+                onClose={() => setInfoAnchor(null)}
+                anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
+                transformOrigin={{ vertical: 'top', horizontal: 'left' }}
+                PaperProps={{ sx: { maxWidth: 320, borderRadius: 2, p: 0 } }}
+              >
+                <Box sx={{ px: 2, pt: 1.5, pb: 0.5 }}>
+                  <Typography variant='subtitle2' sx={{ fontWeight: 700 }}>How to use Column Settings</Typography>
+                </Box>
+                <List dense disablePadding sx={{ px: 1, pb: 1 }}>
+                  <ListItem sx={{ alignItems: 'flex-start', py: 0.5 }}>
+                    <ListItemText
+                      primary='Direction chips (Req → TC / TC → Req)'
+                      secondary='Switch between the two trace query directions. Each direction has fully independent column settings.'
+                      primaryTypographyProps={{ variant: 'body2', fontWeight: 600 }}
+                      secondaryTypographyProps={{ variant: 'caption' }}
+                    />
+                  </ListItem>
+                  <ListItem sx={{ alignItems: 'flex-start', py: 0.5 }}>
+                    <ListItemText
+                      primary='Requirement / Test Case tabs'
+                      secondary='Switch between the two work item types within the selected direction.'
+                      primaryTypographyProps={{ variant: 'body2', fontWeight: 600 }}
+                      secondaryTypographyProps={{ variant: 'caption' }}
+                    />
+                  </ListItem>
+                  <ListItem sx={{ alignItems: 'flex-start', py: 0.5 }}>
+                    <ListItemText
+                      primary='Column tile — click to show / hide'
+                      secondary='Click a tile to toggle column visibility. Strikethrough means the column is hidden in the output.'
+                      primaryTypographyProps={{ variant: 'body2', fontWeight: 600 }}
+                      secondaryTypographyProps={{ variant: 'caption' }}
+                    />
+                  </ListItem>
+                  <ListItem sx={{ alignItems: 'flex-start', py: 0.5 }}>
+                    <ListItemText
+                      primary='Rename field — type a display name'
+                      secondary='Override the column header in the document. Leave blank to use the original ADO field name.'
+                      primaryTypographyProps={{ variant: 'body2', fontWeight: 600 }}
+                      secondaryTypographyProps={{ variant: 'caption' }}
+                    />
+                  </ListItem>
+                  <ListItem sx={{ alignItems: 'flex-start', py: 0.5 }}>
+                    <ListItemText
+                      primary='Drag handle — reorder columns'
+                      secondary='Drag rows up or down to change the column order in the generated trace tables.'
+                      primaryTypographyProps={{ variant: 'body2', fontWeight: 600 }}
+                      secondaryTypographyProps={{ variant: 'caption' }}
+                    />
+                  </ListItem>
+                  <ListItem sx={{ alignItems: 'flex-start', py: 0.5 }}>
+                    <ListItemText
+                      primary='Reset'
+                      secondary='Clears all renames and visibility overrides for the current direction and side.'
+                      primaryTypographyProps={{ variant: 'body2', fontWeight: 600 }}
+                      secondaryTypographyProps={{ variant: 'caption' }}
+                    />
+                  </ListItem>
+                </List>
+              </Popover>
+              {traceAnalysisMode === 'query' && (reqTestQuery || testReqQuery) ? (
+                reqTestQuery && testReqQuery ? (
+                  <Stack direction='row' spacing={0.75} alignItems='center' sx={{ mt: 0.5, flexWrap: 'wrap', gap: 0.5 }}>
+                    <Tooltip title={reqTestQuery?.title ?? 'No query selected for this direction'} arrow>
+                      <span>
+                        <Chip
+                          label={
+                            <Box component='span' sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+                              Req → TC
+                              {modByDirection['req-test'] > 0 && (
+                                <Box component='span' sx={{ fontSize: '0.62rem', fontWeight: 700, bgcolor: 'rgba(0,0,0,0.15)', borderRadius: '10px', px: 0.6, py: 0.1, lineHeight: 1.4 }}>
+                                  {modByDirection['req-test']}
+                                </Box>
+                              )}
+                            </Box>
+                          }
+                          size='small'
+                          clickable={!!reqTestQuery}
+                          disabled={!reqTestQuery}
+                          onClick={reqTestQuery ? () => { setSelectedQuery('req-test'); setSearchText(''); } : undefined}
+                          sx={{
+                            fontWeight: selectedQuery === 'req-test' ? 600 : 400,
+                            bgcolor: selectedQuery === 'req-test' ? '#b8cfe6' : 'transparent',
+                            border: '1px solid',
+                            borderColor: selectedQuery === 'req-test' ? '#b8cfe6' : 'divider',
+                            transition: 'all 0.15s ease',
+                            '&:hover': { bgcolor: selectedQuery === 'req-test' ? '#a8bfd6' : 'action.hover' },
+                          }}
+                        />
+                      </span>
+                    </Tooltip>
+                    <Tooltip title={testReqQuery?.title ?? 'No query selected for this direction'} arrow>
+                      <span>
+                        <Chip
+                          label={
+                            <Box component='span' sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+                              TC → Req
+                              {modByDirection['test-req'] > 0 && (
+                                <Box component='span' sx={{ fontSize: '0.62rem', fontWeight: 700, bgcolor: 'rgba(0,0,0,0.15)', borderRadius: '10px', px: 0.6, py: 0.1, lineHeight: 1.4 }}>
+                                  {modByDirection['test-req']}
+                                </Box>
+                              )}
+                            </Box>
+                          }
+                          size='small'
+                          clickable={!!testReqQuery}
+                          disabled={!testReqQuery}
+                          onClick={testReqQuery ? () => { setSelectedQuery('test-req'); setSearchText(''); } : undefined}
+                          sx={{
+                            fontWeight: selectedQuery === 'test-req' ? 600 : 400,
+                            bgcolor: selectedQuery === 'test-req' ? '#cdc5df' : 'transparent',
+                            border: '1px solid',
+                            borderColor: selectedQuery === 'test-req' ? '#cdc5df' : 'divider',
+                            transition: 'all 0.15s ease',
+                            '&:hover': { bgcolor: selectedQuery === 'test-req' ? '#bdb5cf' : 'action.hover' },
+                          }}
+                        />
+                      </span>
+                    </Tooltip>
+                    <Tooltip title={(selectedQuery === 'req-test' ? reqTestQuery?.title : testReqQuery?.title) ?? ''} arrow>
+                      <Typography variant='caption' sx={{ color: 'text.disabled', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', maxWidth: 220 }}>
+                        {selectedQuery === 'req-test' ? reqTestQuery?.title : testReqQuery?.title}
+                      </Typography>
+                    </Tooltip>
+                  </Stack>
+                ) : (
+                  <Typography variant='caption' sx={{ color: 'text.secondary', mt: 0.5, display: 'block' }}>
+                    {reqTestQuery ? `Req → TC: ${reqTestQuery.title}` : `TC → Req: ${testReqQuery.title}`}
+                  </Typography>
+                )
+              ) : (
+                <Typography variant='caption' color='text.secondary'>Show/hide, rename, or reorder columns in the generated trace tables</Typography>
+              )}
             </Box>
             <Tooltip title={hasMappings ? `Reset ${selectedType} columns` : 'No changes to reset'}>
               <span>
-                <Button size='small' color='warning' onClick={handleClear} disabled={!hasMappings} startIcon={<DeleteSweepIcon />} sx={{ textTransform: 'none', mt: 0.25 }}>
+                <Button size='small' color='warning' onClick={handleClear} disabled={!hasMappings} startIcon={<DeleteSweepIcon />} sx={{ textTransform: 'none', mt: 0.25, flexShrink: 0 }}>
                   Reset
                 </Button>
               </span>
@@ -386,7 +651,14 @@ const FieldDisplayMappingDialog = ({
 
         <DialogContent sx={{ pt: '12px !important' }}>
           <Stack spacing={1.5}>
-            {/* Side tabs */}
+
+            {traceAnalysisMode === 'linkedRequirement' && (
+              <Alert severity='info' sx={{ py: 0.5 }}>
+                In linked mode only Customer ID is configurable. Switch to query mode for full column control.
+              </Alert>
+            )}
+
+            {/* Side tabs — fill colors restored */}
             <ToggleButtonGroup
               value={selectedType}
               exclusive
@@ -401,8 +673,8 @@ const FieldDisplayMappingDialog = ({
                 '& .MuiToggleButton-root[value="Test Case"].Mui-selected': { backgroundColor: TYPE_COLORS_SELECTED['Test Case'], color: 'text.primary', fontWeight: 600, '&:hover': { backgroundColor: TYPE_COLORS_SELECTED['Test Case'] } },
               }}
             >
-              <ToggleButton value='Requirement'><Box sx={{ display: 'flex', alignItems: 'center' }}>Requirement<TabBadge type='Requirement' /></Box></ToggleButton>
-              <ToggleButton value='Test Case'><Box sx={{ display: 'flex', alignItems: 'center' }}>Test Case<TabBadge type='Test Case' /></Box></ToggleButton>
+              <ToggleButton value='Requirement'><Box sx={{ display: 'flex', alignItems: 'center' }}>Requirement<TabBadge type='Requirement' count={modCountByType['Requirement']} /></Box></ToggleButton>
+              <ToggleButton value='Test Case'><Box sx={{ display: 'flex', alignItems: 'center' }}>Test Case<TabBadge type='Test Case' count={modCountByType['Test Case']} /></Box></ToggleButton>
             </ToggleButtonGroup>
 
             {/* Linked-requirements notice */}
@@ -458,8 +730,8 @@ const FieldDisplayMappingDialog = ({
                       key={field.referenceName}
                       field={field}
                       selectedType={selectedType}
-                      workingMapping={workingMapping}
-                      workingVisibility={workingVisibility}
+                      workingMapping={workingMapping[selectedQuery] || {}}
+                      workingVisibility={workingVisibility[selectedQuery] || {}}
                       typeColor={typeColor}
                       onToggleVisibility={handleToggleVisibility}
                       onFieldOverride={handleFieldOverride}

--- a/src/components/dialogs/TraceAnalysisDialog.jsx
+++ b/src/components/dialogs/TraceAnalysisDialog.jsx
@@ -15,7 +15,7 @@ import {
   Typography,
 } from '@mui/material';
 import ManageSearchIcon from '@mui/icons-material/ManageSearch';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import QueryTree from '../common/QueryTree';
 import OverlayLoader from '../common/OverlayLoader';
 import { observer } from 'mobx-react';
@@ -51,7 +51,7 @@ const TraceAnalysisDialog = observer(
             reqTestTree: reqTestQueries?.reqTestTree ? [reqTestQueries.reqTestTree] : [],
             testReqTree: reqTestQueries?.testReqTree ? [reqTestQueries.testReqTree] : [],
           }))
-        : setQueryTrees(defaultSelectedQueries);
+        : setQueryTrees({ reqTestTree: [], testReqTree: [] });
     }, [sharedQueries.acquiredTrees]);
 
     const handleTraceAnalysisChange = (value) => {
@@ -63,20 +63,34 @@ const TraceAnalysisDialog = observer(
       }
     };
 
-    const handleCommonColumnChange = (value) => {
-      setTraceAnalysisRequest((prev) => ({ ...prev, includeCommonColumnsMode: value }));
-    };
-
     const handleClickOpen = () => {
       setOpenDialog(true);
     };
 
-    const onReqTestQuerySelected = (selectedQuery) => {
-      setTraceAnalysisRequest((prev) => ({ ...prev, reqTestQuery: selectedQuery }));
+    const reqTestTokenRef = useRef(0);
+    const onReqTestQuerySelected = async (selectedQuery) => {
+      const token = ++reqTestTokenRef.current;
+      let next = selectedQuery;
+      if (selectedQuery?.id) {
+        const fresh = await store.fetchQueryDefinition({ queryId: selectedQuery.id });
+        if (reqTestTokenRef.current !== token) return;
+        if (fresh) next = { ...selectedQuery, columns: fresh.columns, ...(fresh.wiql ? { wiql: fresh.wiql } : {}) };
+      }
+      if (reqTestTokenRef.current !== token) return;
+      setTraceAnalysisRequest((prev) => ({ ...prev, reqTestQuery: next }));
     };
 
-    const onTestReqQuerySelected = (selectedQuery) => {
-      setTraceAnalysisRequest((prev) => ({ ...prev, testReqQuery: selectedQuery }));
+    const testReqTokenRef = useRef(0);
+    const onTestReqQuerySelected = async (selectedQuery) => {
+      const token = ++testReqTokenRef.current;
+      let next = selectedQuery;
+      if (selectedQuery?.id) {
+        const fresh = await store.fetchQueryDefinition({ queryId: selectedQuery.id });
+        if (testReqTokenRef.current !== token) return;
+        if (fresh) next = { ...selectedQuery, columns: fresh.columns, ...(fresh.wiql ? { wiql: fresh.wiql } : {}) };
+      }
+      if (testReqTokenRef.current !== token) return;
+      setTraceAnalysisRequest((prev) => ({ ...prev, testReqQuery: next }));
     };
 
     const handleClose = () => {
@@ -127,37 +141,6 @@ const TraceAnalysisDialog = observer(
       </Box>
     );
 
-    const includeSpecialColumnsToggle = (
-      <Box>
-        <FormLabel id='include-special-columns-radio'>Include Common Columns</FormLabel>
-        <RadioGroup
-          defaultValue='both'
-          row
-          name='include-special-columns-radio'
-          value={traceAnalysisRequest.includeCommonColumnsMode}
-          onChange={(event) => {
-            handleCommonColumnChange(event.target.value);
-          }}
-        >
-          <FormControlLabel
-            value='both'
-            label='Both'
-            control={<Radio />}
-          />
-          <FormControlLabel
-            value='reqOnly'
-            label='Requirement Only'
-            control={<Radio />}
-          />
-          <FormControlLabel
-            value='testOnly'
-            label='Test Case Only'
-            control={<Radio />}
-          />
-        </RadioGroup>
-      </Box>
-    );
-
     return (
       <>
         <Tooltip title='Open Trace Analysis Dialog'>
@@ -202,7 +185,6 @@ const TraceAnalysisDialog = observer(
                     timeout='auto'
                     unmountOnExit
                   >
-                    {includeSpecialColumnsToggle}
                     <Box>
                       <Typography variant='subtitle1'>Select a Requirement to Test Case Query</Typography>
                       <div>

--- a/src/store/DataStore.jsx
+++ b/src/store/DataStore.jsx
@@ -1685,6 +1685,11 @@ class DocGenDataStore {
         normalizedPath,
       );
       const data = this.mapHistoricalQueriesFromSharedTree(sharedQueryPayload);
+      if (data.length === 0) {
+        toast.warn(
+          'No historical queries found. If queries are expected, some query folders may have failed to load — check server logs.',
+        );
+      }
       this.setHistoricalQueries(data);
       return this.historicalQueries;
     } catch (err) {

--- a/src/store/DataStore.jsx
+++ b/src/store/DataStore.jsx
@@ -713,6 +713,7 @@ class DocGenDataStore {
       fetchFieldsByType: action,
       setFieldsByType: action,
       fetchTraceColumns: action,
+      fetchQueryDefinition: action,
       setHistoricalAsOfResult: action,
       setHistoricalCompareResult: action,
       fetchHistoricalAsOfResults: action,
@@ -878,6 +879,7 @@ class DocGenDataStore {
     testSuiteListLoading: false,
     fieldsByTypeLoadingState: false,
     traceColumnsLoadingState: false,
+    queryDefinitionLoadingState: false,
     contentControlsLoadingState: false,
     documentsLoadingState: false,
     templatesLoadingState: false,
@@ -1886,9 +1888,21 @@ class DocGenDataStore {
       });
     } catch (err) {
       logger.error(`Error fetching trace columns: ${err.message}`);
-      return { Requirement: [], 'Test Case': [] };
+      return {};
     } finally {
       runInAction(() => { this.loadingState.traceColumnsLoadingState = false; });
+    }
+  }
+
+  async fetchQueryDefinition({ queryId } = {}) {
+    runInAction(() => { this.loadingState.queryDefinitionLoadingState = true; });
+    try {
+      return await this.azureRestClient.getQueryDefinition(queryId, this.teamProject);
+    } catch (err) {
+      logger.error(`Error fetching query definition: ${err.message}`);
+      return null;
+    } finally {
+      runInAction(() => { this.loadingState.queryDefinitionLoadingState = false; });
     }
   }
 

--- a/src/store/actions/AzureDevopsRestApi.jsx
+++ b/src/store/actions/AzureDevopsRestApi.jsx
@@ -135,6 +135,19 @@ export default class AzureDevopsRestApi {
     });
   }
 
+  async getQueryDefinition(queryId = null, teamProjectId = '') {
+    return this._wrap(async () => {
+      const res = await axios.get(
+        `${C.jsonDocument_url}/azure/queries/${encodeURIComponent(queryId || '')}/definition`,
+        {
+          headers: this._headers(),
+          params: { teamProjectId: this._normalizeTeamProjectId(teamProjectId) },
+        },
+      );
+      return res.data;
+    });
+  }
+
   async getHistoricalQueries(teamProjectId = '', path = 'shared') {
     return this._wrap(async () => {
       const res = await axios.get(`${C.jsonDocument_url}/azure/queries/historical`, {


### PR DESCRIPTION
FieldDisplayMappingDialog:
- Add iconOnly prop — renders IconButton+badge instead of full button
- Direction chips: hide selector when only one direction has a query; show caption instead
- Mode-aware trigger tooltip (none/linkedRequirement/query)
- Alert info note in dialog content for linkedRequirement mode
- Reset selectedQuery to correct direction on every open (useEffect on open)
- TabBadge lifted to module scope (was re-created every render)
- O(n) Set replace O(n²) order.includes in visibleFields memo
- Separate append-only workingOrder augment effect (no clobber on late metadata)
- modByDirection useMemo for per-direction mod count in chips
- iconOnly disabled when testReqQuery null

TraceAnalysisDialog:
- Fix setQueryTrees reset: was passing wrong keys (reqTestQuery/testReqQuery), now passes { reqTestTree: [], testReqTree: [] }
- Replace both query-selected handlers with per-slot token guards (stale-response, not re-entry)

trace column settings UX overhaul + dialog bugs

FieldDisplayMappingDialog:
- Add iconOnly prop — renders IconButton+badge instead of full button
- Direction chips: hide selector when only one direction has a query; show caption instead
- Mode-aware trigger tooltip (none/linkedRequirement/query)
- Alert info note in dialog content for linkedRequirement mode
- Reset selectedQuery to correct direction on every open (useEffect on open)
- TabBadge lifted to module scope (was re-created every render)
- O(n) Set replace O(n²) order.includes in visibleFields memo
- Separate append-only workingOrder augment effect (no clobber on late metadata)
- modByDirection useMemo for per-direction mod count in chips
- iconOnly disabled when testReqQuery null

TraceAnalysisDialog:
- Fix setQueryTrees reset: was passing wrong keys (reqTestQuery/testReqQuery), now passes { reqTestTree: [], testReqTree: [] }
- Replace both query-selected handlers with per-slot token guards (stale-response, not re-entry)

DetailedStepsSettingsDialog:
- Fix useState → useEffect for prevStepExecution prop sync
- Fix operator precedence bug: !tree.length > 0 → !(tree?.length > 0)
- Hide Include Customer Id when requirementInclusionMode === 'query'
- Remove dead label='Requirement Type' prop from FormLabel
- Scope overflow:visible from Dialog paper → DialogContent only
- Add Dividers between Flat/Attachments/Requirements sections
- Move FieldDisplayMappingDialog to render after QueryTree (UX flow fix)
- Merge two Collapses into one row: QueryTree flex + iconOnly Column Settings
- Add info popover in DialogTitle with 5-item guide

TestContentSelector:
- sanitizeFieldMap: detect legacy type-keyed favorites, return {} to prevent blank dialog
- Force columnMetadata: {} on favorite load (never trust persisted metadata)
- console.error → logger.error
- Add || {} to columnMetadata prop
- Group Trace Analysis + Column Settings buttons in bordered box (visual dependency)