### PR TITLE
#297677 - align historical query sort order with backend depth-first …

### DIFF
--- a/src/utils/historicalQuery.js
+++ b/src/utils/historicalQuery.js
@@ -79,6 +79,9 @@ const toQueryListFromArray = (items = []) => {
     });
   });
   mapped.sort((a, b) => {
+    const aDepth = a.path.split('/').length;
+    const bDepth = b.path.split('/').length;
+    if (aDepth !== bDepth) return bDepth - aDepth;
     const byPath = a.path.localeCompare(b.path);
     if (byPath !== 0) return byPath;
     return a.queryName.localeCompare(b.queryName);


### PR DESCRIPTION
…sort

toQueryListFromArray re-sorted the backend payload by path ascending, overriding the depth-descending order and causing folders to appear at the bottom of each tree level.