### PR TITLE
#298810 - Fix Trace Analysis Column Settings: semi-live columns, favorite drift, seeding bug

### DIFF
--- a/src/components/common/table/TestContentSelector.jsx
+++ b/src/components/common/table/TestContentSelector.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback, useMemo } from 'react';
+import React, { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 /**
  * TestContentSelector (STD/STP)
  * Manages test plan/suites and related options for test-based document tabs.
@@ -20,6 +20,7 @@ import {
 } from '@mui/material';
 import TraceAnalysisDialog from '../../dialogs/TraceAnalysisDialog';
 import FieldDisplayMappingDialog from '../../dialogs/FieldDisplayMappingDialog';
+import { deriveFieldList } from '../../../utils/traceColumnFields';
 import { observer } from 'mobx-react';
 import { validateQuery } from '../../../utils/queryValidation';
 import { toast } from 'react-toastify';
@@ -32,6 +33,7 @@ import { suiteIdCollection } from '../../../utils/sessionPersistence';
 import useTabStatePersistence from '../../../hooks/useTabStatePersistence';
 import RestoreBackdrop from '../RestoreBackdrop';
 import { buildTestContentRequestData } from './testContentRequestData';
+import { describeColumnDrift, formatColumnDriftMessage, pruneStaleFieldConfig } from '../../../utils/columnDrift';
 
 const defaultSelectedQueries = {
   traceAnalysisMode: 'none',
@@ -425,21 +427,79 @@ const TestContentSelector = observer(
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [selectorTag, store.sharedQueries]);
 
-    // Fetch per-side valid columns from backend when trace queries change (query mode only)
+    // Fetch per-side valid columns from backend — used both on trace query change and as the
+    // semi-live "refresh" the Column Settings dialog triggers on open / via its refresh button.
+    // A generation counter (not just a busy flag) ensures a stale in-flight response never
+    // overwrites state once a newer request has been issued for a different query selection.
+    const [isRefreshingColumns, setIsRefreshingColumns] = useState(false);
+    const columnsFetchGenerationRef = useRef(0);
+
+    // Flags that the state currently in traceAnalysisRequest came from a favorite load, so the
+    // next successful column fetch should check for ADO column drift vs. the saved config.
+    // store.selectedFavorite is the same signal useTabStatePersistence uses to distinguish a
+    // favorite load from a session restore, so this only fires on an actual favorite load.
+    const pendingFavoriteColumnCheckRef = useRef(false);
     useEffect(() => {
-      if (traceAnalysisRequest.traceAnalysisMode !== 'query') return;
-      if (!traceAnalysisRequest.reqTestQuery && !traceAnalysisRequest.testReqQuery) return;
-      let cancelled = false;
-      store.fetchTraceColumns({
-        reqTestQuery: traceAnalysisRequest.reqTestQuery,
-        testReqQuery: traceAnalysisRequest.testReqQuery,
-      }).then((result) => {
-        if (cancelled) return;
-        setTraceAnalysisRequest((prev) => ({ ...prev, columnMetadata: result }));
-      }).catch(() => {
+      if (store.selectedFavorite?.dataToSave) pendingFavoriteColumnCheckRef.current = true;
+    }, [store.selectedFavorite]);
+
+    // Reassigned every render so it always closes over the LATEST traceAnalysisRequest.
+    // Without this, a useCallback memoized only on [mode, reqTestQuery?.id, testReqQuery?.id]
+    // would keep using stale fieldOrder/fieldDisplayMapping/fieldVisibility on any refresh
+    // triggered without those ids changing (dialog refresh button, dialog reopen, reselecting
+    // the same favorite) — reporting a column as "removed" even after it was re-added in ADO.
+    const refreshTraceColumnsImplRef = useRef();
+    refreshTraceColumnsImplRef.current = async () => {
+      const current = traceAnalysisRequest;
+      if (current.traceAnalysisMode !== 'query' || (!current.reqTestQuery && !current.testReqQuery)) {
+        pendingFavoriteColumnCheckRef.current = false;
+        return;
+      }
+      const generation = ++columnsFetchGenerationRef.current;
+      setIsRefreshingColumns(true);
+      try {
+        const result = await store.fetchTraceColumns({
+          reqTestQuery: current.reqTestQuery,
+          testReqQuery: current.testReqQuery,
+        });
+        if (generation !== columnsFetchGenerationRef.current) return; // superseded by a newer request
+
+        const fieldsByQuery = deriveFieldList(current.traceAnalysisMode, current.reqTestQuery, current.testReqQuery, result);
+        const queries = { 'req-test': current.reqTestQuery, 'test-req': current.testReqQuery };
+
+        // Prune saved rename/hide/order entries for columns no longer in ADO — otherwise a
+        // deleted column's stale entry keeps counting as a "pending change" in the trigger badge
+        // forever, even though the dialog correctly stops showing that column. Computed before
+        // the drift toast so the toast can tell the user whether this fix still needs saving.
+        const pruned = pruneStaleFieldConfig(fieldsByQuery, queries, current.fieldOrder, current.fieldVisibility, current.fieldDisplayMapping);
+
+        if (pendingFavoriteColumnCheckRef.current) {
+          pendingFavoriteColumnCheckRef.current = false;
+          const drift = describeColumnDrift(fieldsByQuery, queries, current.fieldOrder, current.fieldDisplayMapping, current.fieldVisibility);
+          const message = formatColumnDriftMessage(drift, 4, pruned.changed);
+          if (message) toast.info(message);
+        }
+
+        setTraceAnalysisRequest((prev) => ({
+          ...prev,
+          columnMetadata: result,
+          fieldOrder: pruned.fieldOrder,
+          fieldVisibility: pruned.fieldVisibility,
+          fieldDisplayMapping: pruned.fieldDisplayMapping,
+        }));
+      } catch {
         // best-effort: failure is non-blocking, dialog falls back to merged columns
-      });
-      return () => { cancelled = true; };
+      } finally {
+        if (generation === columnsFetchGenerationRef.current) setIsRefreshingColumns(false);
+      }
+    };
+
+    // Stable identity (safe to pass as a prop without causing extra effect re-runs) that always
+    // delegates to the latest implementation above.
+    const refreshTraceColumns = useCallback(() => refreshTraceColumnsImplRef.current(), []);
+
+    useEffect(() => {
+      refreshTraceColumns();
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [traceAnalysisRequest.traceAnalysisMode, traceAnalysisRequest.reqTestQuery?.id, traceAnalysisRequest.testReqQuery?.id]);
 
@@ -644,6 +704,8 @@ const TestContentSelector = observer(
                         reqTestQuery={traceAnalysisRequest.reqTestQuery}
                         testReqQuery={traceAnalysisRequest.testReqQuery}
                         columnMetadata={traceAnalysisRequest.columnMetadata || {}}
+                        onRefreshColumns={refreshTraceColumns}
+                        isRefreshingColumns={isRefreshingColumns}
                       />
                     </Box>
                   }

--- a/src/components/dialogs/DetailedStepsSettingsDialog.jsx
+++ b/src/components/dialogs/DetailedStepsSettingsDialog.jsx
@@ -24,10 +24,13 @@ import {
 } from '@mui/material';
 import StairsIcon from '@mui/icons-material/Stairs';
 import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback, useRef } from 'react';
+import { toast } from 'react-toastify';
 import QueryTree from '../common/QueryTree';
 import OverlayLoader from '../common/OverlayLoader';
 import FieldDisplayMappingDialog from './FieldDisplayMappingDialog';
+import { deriveFieldList } from '../../utils/traceColumnFields';
+import { describeColumnDrift, formatColumnDriftMessage, pruneStaleFieldConfig } from '../../utils/columnDrift';
 
 const DetailedStepsSettingsDialog = ({
   store,
@@ -42,21 +45,80 @@ const DetailedStepsSettingsDialog = ({
     if (prevStepExecution) setStepExecutionState(prevStepExecution);
   }, [prevStepExecution]);
 
-  // Fetch per-side valid columns from backend when the trace query changes (query mode only)
+  // Fetch per-side valid columns from backend — used both on trace query change and as the
+  // semi-live "refresh" the Column Settings dialog triggers on open / via its refresh button.
+  // A generation counter ensures a stale in-flight response never overwrites state once a
+  // newer request has been issued for a different query selection.
+  const [isRefreshingColumns, setIsRefreshingColumns] = useState(false);
+  const columnsFetchGenerationRef = useRef(0);
+
+  // Flags that stepExecutionState currently reflects a favorite load, so the next successful
+  // column fetch should check for ADO column drift vs. the saved config. store.selectedFavorite
+  // is the same signal useTabStatePersistence uses to distinguish a favorite load from a
+  // session restore, so this only fires on an actual favorite load.
+  const pendingFavoriteColumnCheckRef = useRef(false);
   useEffect(() => {
-    const { requirementInclusionMode, testReqQuery } = stepExecutionState.generateRequirements || {};
-    if (requirementInclusionMode !== 'query' || !testReqQuery) return;
-    let cancelled = false;
-    store.fetchTraceColumns({ reqTestQuery: undefined, testReqQuery }).then((result) => {
-      if (cancelled) return;
+    if (store.selectedFavorite?.dataToSave) pendingFavoriteColumnCheckRef.current = true;
+  }, [store.selectedFavorite]);
+
+  // Reassigned every render so it always closes over the LATEST stepExecutionState. Without
+  // this, a useCallback memoized only on [requirementInclusionMode, testReqQuery?.id] would keep
+  // using stale fieldOrder/fieldDisplayMapping/fieldVisibility on any refresh triggered without
+  // those changing (dialog refresh button, dialog reopen, reselecting the same favorite) —
+  // reporting a column as "removed" even after it was re-added in ADO.
+  const refreshTraceColumnsImplRef = useRef();
+  refreshTraceColumnsImplRef.current = async () => {
+    const { requirementInclusionMode, testReqQuery, fieldOrder, fieldVisibility, fieldDisplayMapping } =
+      stepExecutionState.generateRequirements || {};
+    if (requirementInclusionMode !== 'query' || !testReqQuery) {
+      pendingFavoriteColumnCheckRef.current = false;
+      return;
+    }
+    const generation = ++columnsFetchGenerationRef.current;
+    setIsRefreshingColumns(true);
+    try {
+      const result = await store.fetchTraceColumns({ reqTestQuery: undefined, testReqQuery });
+      if (generation !== columnsFetchGenerationRef.current) return; // superseded by a newer request
+
+      const fieldsByQuery = deriveFieldList(requirementInclusionMode, null, testReqQuery, result);
+      const queries = { 'test-req': testReqQuery };
+
+      // Prune saved rename/hide/order entries for columns no longer in ADO — otherwise a
+      // deleted column's stale entry keeps counting as a "pending change" in the trigger badge.
+      // Computed before the drift toast so the toast can tell the user whether this fix still
+      // needs saving.
+      const pruned = pruneStaleFieldConfig(fieldsByQuery, queries, fieldOrder, fieldVisibility, fieldDisplayMapping);
+
+      if (pendingFavoriteColumnCheckRef.current) {
+        pendingFavoriteColumnCheckRef.current = false;
+        const drift = describeColumnDrift(fieldsByQuery, queries, fieldOrder, fieldDisplayMapping, fieldVisibility);
+        const message = formatColumnDriftMessage(drift, 4, pruned.changed);
+        if (message) toast.info(message);
+      }
+
       setStepExecutionState((prev) => ({
         ...prev,
-        generateRequirements: { ...prev.generateRequirements, columnMetadata: result },
+        generateRequirements: {
+          ...prev.generateRequirements,
+          columnMetadata: result,
+          fieldOrder: pruned.fieldOrder,
+          fieldVisibility: pruned.fieldVisibility,
+          fieldDisplayMapping: pruned.fieldDisplayMapping,
+        },
       }));
-    }).catch(() => {
+    } catch {
       // best-effort: failure is non-blocking, dialog falls back to merged columns
-    });
-    return () => { cancelled = true; };
+    } finally {
+      if (generation === columnsFetchGenerationRef.current) setIsRefreshingColumns(false);
+    }
+  };
+
+  // Stable identity (safe to pass as a prop without causing extra effect re-runs) that always
+  // delegates to the latest implementation above.
+  const refreshTraceColumns = useCallback(() => refreshTraceColumnsImplRef.current(), []);
+
+  useEffect(() => {
+    refreshTraceColumns();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [stepExecutionState.generateRequirements?.requirementInclusionMode, stepExecutionState.generateRequirements?.testReqQuery?.id]);
   const attachmentTypeElements = (attachmentProp) => {
@@ -325,6 +387,8 @@ const DetailedStepsSettingsDialog = ({
               traceAnalysisMode={stepExecutionState.generateRequirements.requirementInclusionMode}
               testReqQuery={stepExecutionState.generateRequirements.testReqQuery}
               columnMetadata={stepExecutionState.generateRequirements.columnMetadata}
+              onRefreshColumns={refreshTraceColumns}
+              isRefreshingColumns={isRefreshingColumns}
             />
           </Box>
         </Collapse>

--- a/src/components/dialogs/FieldDisplayMappingDialog.jsx
+++ b/src/components/dialogs/FieldDisplayMappingDialog.jsx
@@ -19,6 +19,8 @@ import {
   Typography,
   InputAdornment,
   Stack,
+  Skeleton,
+  LinearProgress,
 } from '@mui/material';
 import EditNoteIcon from '@mui/icons-material/EditNote';
 import SearchIcon from '@mui/icons-material/Search';
@@ -29,6 +31,7 @@ import LockIcon from '@mui/icons-material/Lock';
 import VisibilityIcon from '@mui/icons-material/Visibility';
 import VisibilityOffIcon from '@mui/icons-material/VisibilityOff';
 import DragIndicatorIcon from '@mui/icons-material/DragIndicator';
+import RefreshIcon from '@mui/icons-material/Refresh';
 import React, { useEffect, useMemo, useState } from 'react';
 import {
   DndContext,
@@ -45,10 +48,23 @@ import {
 } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 import { COLOR_REQ, COLOR_TEST_CASE } from '../../constants/traceColors';
+import { ALWAYS_VISIBLE_REFS, deriveFieldList } from '../../utils/traceColumnFields';
 
 const TYPE_COLORS = { Requirement: COLOR_REQ, 'Test Case': COLOR_TEST_CASE };
 // TODO: theme token — no equivalent in tokens.js; replace when palette is extended
 const TYPE_COLORS_SELECTED = { Requirement: '#b8cfe6', 'Test Case': '#cdc5df' };
+
+// Placeholder row shown while columns are being fetched from ADO, matching SortableFieldRow's shape.
+const COLUMN_ROW_SKELETON_COUNT = 5;
+function ColumnRowSkeleton() {
+  return (
+    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, py: 0.75, px: 0.5 }}>
+      <Skeleton variant='circular' width={16} height={16} sx={{ flexShrink: 0 }} />
+      <Skeleton variant='rounded' width={150} height={34} sx={{ flexShrink: 0 }} />
+      <Skeleton variant='text' sx={{ flex: 1 }} />
+    </Box>
+  );
+}
 
 function TabBadge({ type, count }) {
   if (!count) return null;
@@ -57,62 +73,6 @@ function TabBadge({ type, count }) {
       {count}
     </Box>
   );
-}
-
-// ADO referenceNames + linked-mode pseudo-keys that are always shown and never dragged
-const ALWAYS_VISIBLE_REFS = new Set(['System.Id', 'System.Title', 'Req ID', 'Test Case ID', 'Title']);
-const EXCLUDED_FIELD_REFS = new Set(['System.WorkItemType']);
-
-// Locked columns in linked mode (only Customer ID is configurable)
-const LINKED_REQ_COLUMNS = {
-  Requirement: [{ referenceName: 'Customer ID', name: 'Customer ID' }],
-  'Test Case': [],
-};
-
-// Returns { 'req-test': { Requirement, 'Test Case' }, 'test-req': { Requirement, 'Test Case' } }
-function deriveFieldList(traceAnalysisMode, reqTestQuery, testReqQuery, columnMetadata) {
-  if (traceAnalysisMode === 'linkedRequirement') {
-    return { 'req-test': LINKED_REQ_COLUMNS, 'test-req': LINKED_REQ_COLUMNS };
-  }
-  if (traceAnalysisMode !== 'query') {
-    return { 'req-test': { Requirement: [], 'Test Case': [] }, 'test-req': { Requirement: [], 'Test Case': [] } };
-  }
-
-  const filterMeta = (cols) =>
-    (cols || []).filter(
-      (c) => c?.referenceName && !EXCLUDED_FIELD_REFS.has(c.referenceName) && !ALWAYS_VISIBLE_REFS.has(c.referenceName)
-    );
-
-  const fallbackFromQuery = (query) => {
-    const seen = new Set();
-    const cols = [];
-    for (const col of (query?.columns || [])) {
-      if (!col?.referenceName || seen.has(col.referenceName)) continue;
-      if (EXCLUDED_FIELD_REFS.has(col.referenceName)) continue;
-      if (ALWAYS_VISIBLE_REFS.has(col.referenceName)) continue;
-      seen.add(col.referenceName);
-      cols.push({ referenceName: col.referenceName, name: col.name });
-    }
-    return cols;
-  };
-
-  const resolveQuerySides = (queryKey, query) => {
-    const meta = columnMetadata?.[queryKey];
-    if (meta) {
-      return {
-        Requirement: filterMeta(meta.Requirement),
-        'Test Case': filterMeta(meta['Test Case']),
-      };
-    }
-    // Fallback: use this query's own declared columns for both sides (loading / no metadata)
-    const fb = fallbackFromQuery(query);
-    return { Requirement: fb, 'Test Case': fb };
-  };
-
-  return {
-    'req-test': resolveQuerySides('req-test', reqTestQuery),
-    'test-req': resolveQuerySides('test-req', testReqQuery),
-  };
 }
 
 function countMods(mappingByType, visibilityByType, type) {
@@ -231,6 +191,8 @@ const FieldDisplayMappingDialog = ({
   testReqQuery = null,
   columnMetadata = {}, // {} = not yet fetched / loading; { 'req-test': { Requirement, 'Test Case' }, 'test-req': { ... } } = fetched per query
   iconOnly = false,
+  onRefreshColumns, // async () => void — re-fetch columnMetadata from ADO (semi-live)
+  isRefreshingColumns = false,
 }) => {
   const [open, setOpen] = useState(false);
   const [infoAnchor, setInfoAnchor] = useState(null);
@@ -243,6 +205,14 @@ const FieldDisplayMappingDialog = ({
     if (!open) return;
     setSelectedQuery(reqTestQuery ? 'req-test' : 'test-req');
   }, [open]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Semi-live columns: re-fetch from ADO every time the dialog is opened, so column
+  // additions/removals made in ADO since the last fetch are picked up without reselecting the query.
+  useEffect(() => {
+    if (!open) return;
+    onRefreshColumns?.();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open]);
   const [searchText, setSearchText] = useState('');
 
   // Auto-correct selectedQuery if the previously selected query is no longer available
@@ -510,6 +480,20 @@ const FieldDisplayMappingDialog = ({
                     <InfoOutlinedIcon sx={{ fontSize: 17 }} />
                   </IconButton>
                 </Tooltip>
+                {onRefreshColumns && (
+                  <Tooltip title='Re-fetch columns from ADO' arrow>
+                    <span>
+                      <IconButton
+                        size='small'
+                        onClick={() => onRefreshColumns()}
+                        disabled={isRefreshingColumns}
+                        sx={{ color: 'text.disabled', '&:hover': { color: 'text.secondary' } }}
+                      >
+                        <RefreshIcon sx={{ fontSize: 17 }} />
+                      </IconButton>
+                    </span>
+                  </Tooltip>
+                )}
               </Stack>
               <Popover
                 open={Boolean(infoAnchor)}
@@ -723,30 +707,39 @@ const FieldDisplayMappingDialog = ({
 
             <Divider />
 
+            {/* Thin progress bar while re-fetching columns that are already showing (refresh button / reopen) */}
+            {isRefreshingColumns && visibleFields.length > 0 && <LinearProgress sx={{ height: 2 }} />}
+
             {/* Column list */}
             <Box sx={{ maxHeight: 340, overflowY: 'auto', mx: -0.5, px: 0.5 }}>
-              {visibleFields.length === 0 && (
-                <Typography variant='body2' color='text.secondary' sx={{ py: 4, textAlign: 'center' }}>
-                  {traceAnalysisMode === 'query' ? 'Select trace queries to see available columns' : 'No configurable columns for this mode'}
-                </Typography>
-              )}
+              {isRefreshingColumns && visibleFields.length === 0 && traceAnalysisMode === 'query' ? (
+                Array.from({ length: COLUMN_ROW_SKELETON_COUNT }).map((_, i) => <ColumnRowSkeleton key={i} />)
+              ) : (
+                <>
+                  {visibleFields.length === 0 && (
+                    <Typography variant='body2' color='text.secondary' sx={{ py: 4, textAlign: 'center' }}>
+                      {traceAnalysisMode === 'query' ? 'Select trace queries to see available columns' : 'No configurable columns for this mode'}
+                    </Typography>
+                  )}
 
-              <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
-                <SortableContext items={visibleFields.map((f) => f.referenceName)} strategy={verticalListSortingStrategy}>
-                  {visibleFields.map((field) => (
-                    <SortableFieldRow
-                      key={field.referenceName}
-                      field={field}
-                      selectedType={selectedType}
-                      workingMapping={workingMapping[selectedQuery] || {}}
-                      workingVisibility={workingVisibility[selectedQuery] || {}}
-                      typeColor={typeColor}
-                      onToggleVisibility={handleToggleVisibility}
-                      onFieldOverride={handleFieldOverride}
-                    />
-                  ))}
-                </SortableContext>
-              </DndContext>
+                  <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+                    <SortableContext items={visibleFields.map((f) => f.referenceName)} strategy={verticalListSortingStrategy}>
+                      {visibleFields.map((field) => (
+                        <SortableFieldRow
+                          key={field.referenceName}
+                          field={field}
+                          selectedType={selectedType}
+                          workingMapping={workingMapping[selectedQuery] || {}}
+                          workingVisibility={workingVisibility[selectedQuery] || {}}
+                          typeColor={typeColor}
+                          onToggleVisibility={handleToggleVisibility}
+                          onFieldOverride={handleFieldOverride}
+                        />
+                      ))}
+                    </SortableContext>
+                  </DndContext>
+                </>
+              )}
             </Box>
           </Stack>
         </DialogContent>

--- a/src/components/dialogs/FieldDisplayMappingDialog.test.jsx
+++ b/src/components/dialogs/FieldDisplayMappingDialog.test.jsx
@@ -31,4 +31,26 @@ describe('FieldDisplayMappingDialog trigger badge', () => {
     expect(markup).toContain('Column Settings');
     expect(markup).toContain('>2<');
   });
+
+  test('renders with onRefreshColumns/isRefreshingColumns props without throwing', () => {
+    const onRefreshColumns = vi.fn();
+    const markup = renderToStaticMarkup(
+      <FieldDisplayMappingDialog
+        fieldDisplayMapping={{}}
+        onMappingChange={vi.fn()}
+        fieldVisibility={{}}
+        onVisibilityChange={vi.fn()}
+        fieldOrder={{}}
+        onOrderChange={vi.fn()}
+        traceAnalysisMode='query'
+        reqTestQuery={{ id: 'req-test-query', title: 'Req to TC' }}
+        onRefreshColumns={onRefreshColumns}
+        isRefreshingColumns={false}
+      />
+    );
+
+    expect(markup).toContain('Column Settings');
+    // Dialog is closed on initial render, so the refresh effect (tied to `open`) must not fire.
+    expect(onRefreshColumns).not.toHaveBeenCalled();
+  });
 });

--- a/src/utils/columnDrift.js
+++ b/src/utils/columnDrift.js
@@ -1,0 +1,137 @@
+import { ALWAYS_VISIBLE_REFS, EXCLUDED_FIELD_REFS } from './traceColumnFields';
+
+// Compares a saved per-query per-side column config (e.g. from a favorite) against the
+// currently live columns (fresh from ADO) and reports which referenceNames were dropped
+// (saved but no longer present) and which were added (present but never saved).
+// `fieldsByQuery` shape: { [queryKey]: { [side]: [{ referenceName, name }] } } — see deriveFieldList.
+// `queries` shape: { [queryKey]: query } where query.columns is the {referenceName, name}[]
+// snapshot captured when the query was selected — the only place we can still recover a dropped
+// column's friendly name, since it's no longer in the fresh fetch by definition.
+// Dropped entries carry the display label (rename override, else the query's own prior name for
+// that column, else referenceName as a last resort) plus which customizations are being
+// discarded (renamed / hidden), so the caller can say more than just "a column was removed".
+export function describeColumnDrift(fieldsByQuery, queries, fieldOrder, fieldDisplayMapping, fieldVisibility) {
+  const droppedByLabel = new Map(); // label -> { wasRenamed, wasHidden }
+  const addedByLabel = new Set();
+
+  for (const [queryKey, sides] of Object.entries(fieldsByQuery || {})) {
+    const priorNameByRef = new Map((queries?.[queryKey]?.columns || []).map((c) => [c.referenceName, c.name]));
+
+    for (const [side, fields] of Object.entries(sides || {})) {
+      const savedRefs = fieldOrder?.[queryKey]?.[side] || [];
+      if (savedRefs.length === 0) continue; // no saved config for this side yet
+
+      const currentByRef = new Map((fields || []).map((f) => [f.referenceName, f.name]));
+      for (const ref of savedRefs) {
+        if (currentByRef.has(ref)) continue;
+        // Fields that are deliberately excluded from fieldsByQuery (System.Id, Work Item Type,
+        // etc.) will never appear in currentByRef even though ADO didn't actually drop them —
+        // a legacy saved entry for one of these (e.g. from before this exclusion existed) is
+        // noise, not real drift.
+        if (ALWAYS_VISIBLE_REFS.has(ref) || EXCLUDED_FIELD_REFS.has(ref)) continue;
+
+        const override = fieldDisplayMapping?.[queryKey]?.[side]?.[ref];
+        const wasHidden = fieldVisibility?.[queryKey]?.[side]?.[ref] === false;
+        const label = override || priorNameByRef.get(ref) || ref;
+        const existing = droppedByLabel.get(label) || { wasRenamed: false, wasHidden: false };
+        droppedByLabel.set(label, {
+          wasRenamed: existing.wasRenamed || Boolean(override),
+          wasHidden: existing.wasHidden || wasHidden,
+        });
+      }
+
+      const savedSet = new Set(savedRefs);
+      for (const [ref, name] of currentByRef) {
+        if (!savedSet.has(ref)) addedByLabel.add(name || ref);
+      }
+    }
+  }
+
+  return {
+    dropped: [...droppedByLabel.entries()].map(([label, info]) => ({ label, ...info })),
+    added: [...addedByLabel],
+  };
+}
+
+// Formats a drift result into a single human-readable sentence, truncating long lists.
+// wasPruned: true when pruneStaleFieldConfig actually changed something for this refresh — the
+// local session state is already fixed, but the favorite in the DB still has the stale entry
+// until the user explicitly saves again, so we tell them that instead of leaving them confused
+// about why the same "removed" toast keeps recurring on this favorite.
+export function formatColumnDriftMessage({ dropped, added }, maxPerList = 4, wasPruned = false) {
+  if (dropped.length === 0 && added.length === 0) return null;
+
+  const describeDropped = (d) => {
+    const tags = [];
+    if (d.wasRenamed) tags.push('renamed');
+    if (d.wasHidden) tags.push('hidden');
+    return tags.length ? `${d.label} (was ${tags.join(', ')})` : d.label;
+  };
+  const truncate = (list, formatter) =>
+    list.length > maxPerList
+      ? `${list.slice(0, maxPerList).map(formatter).join(', ')} +${list.length - maxPerList} more`
+      : list.map(formatter).join(', ');
+
+  const parts = [];
+  if (dropped.length) parts.push(`removed ${truncate(dropped, describeDropped)}`);
+  if (added.length) parts.push(`added ${truncate(added, (x) => x)}`);
+  const base = `Trace Analysis columns changed in ADO since this favorite was saved (${parts.join('; ')}).`;
+  return wasPruned ? `${base} Save this favorite again to keep this fix.` : base;
+}
+
+// Removes referenceNames from saved fieldOrder/fieldVisibility/fieldDisplayMapping that no
+// longer exist in the live query columns, so a deleted-in-ADO column's stale rename/hide/order
+// entry doesn't keep counting as a "pending change" forever. Only prunes sides whose query is
+// actually active (queries[queryKey] truthy) and whose columns were actually fetched
+// (fieldsByQuery[queryKey] present) — an inactive/unfetched direction's saved config is left
+// untouched so re-selecting it later doesn't lose prior customization.
+// Identity-stable: returns the original object references when nothing needed pruning.
+export function pruneStaleFieldConfig(fieldsByQuery, queries, fieldOrder, fieldVisibility, fieldDisplayMapping) {
+  let orderChanged = false;
+  let visibilityChanged = false;
+  let mappingChanged = false;
+  const nextOrder = { ...fieldOrder };
+  const nextVisibility = { ...fieldVisibility };
+  const nextMapping = { ...fieldDisplayMapping };
+
+  for (const queryKey of ['req-test', 'test-req']) {
+    if (!queries?.[queryKey]) continue;
+    const sides = fieldsByQuery?.[queryKey];
+    if (!sides) continue;
+
+    for (const side of ['Requirement', 'Test Case']) {
+      const currentRefs = new Set((sides[side] || []).map((f) => f.referenceName));
+
+      const savedOrder = fieldOrder?.[queryKey]?.[side];
+      if (savedOrder && savedOrder.some((ref) => !currentRefs.has(ref))) {
+        nextOrder[queryKey] = { ...(nextOrder[queryKey] || {}), [side]: savedOrder.filter((ref) => currentRefs.has(ref)) };
+        orderChanged = true;
+      }
+
+      const savedVisibility = fieldVisibility?.[queryKey]?.[side];
+      if (savedVisibility) {
+        const entries = Object.entries(savedVisibility).filter(([ref]) => currentRefs.has(ref));
+        if (entries.length !== Object.keys(savedVisibility).length) {
+          nextVisibility[queryKey] = { ...(nextVisibility[queryKey] || {}), [side]: Object.fromEntries(entries) };
+          visibilityChanged = true;
+        }
+      }
+
+      const savedMapping = fieldDisplayMapping?.[queryKey]?.[side];
+      if (savedMapping) {
+        const entries = Object.entries(savedMapping).filter(([ref]) => currentRefs.has(ref));
+        if (entries.length !== Object.keys(savedMapping).length) {
+          nextMapping[queryKey] = { ...(nextMapping[queryKey] || {}), [side]: Object.fromEntries(entries) };
+          mappingChanged = true;
+        }
+      }
+    }
+  }
+
+  return {
+    fieldOrder: orderChanged ? nextOrder : fieldOrder,
+    fieldVisibility: visibilityChanged ? nextVisibility : fieldVisibility,
+    fieldDisplayMapping: mappingChanged ? nextMapping : fieldDisplayMapping,
+    changed: orderChanged || visibilityChanged || mappingChanged,
+  };
+}

--- a/src/utils/columnDrift.test.js
+++ b/src/utils/columnDrift.test.js
@@ -1,0 +1,211 @@
+import { describe, expect, test } from 'vitest';
+import { describeColumnDrift, formatColumnDriftMessage, pruneStaleFieldConfig } from './columnDrift';
+
+describe('describeColumnDrift', () => {
+  test('resolves a dropped column label from the query\'s prior columns snapshot when no rename exists', () => {
+    const fieldsByQuery = {
+      'req-test': { Requirement: [{ referenceName: 'System.NodeName', name: 'Node Name' }], 'Test Case': [] },
+      'test-req': { Requirement: [], 'Test Case': [] },
+    };
+    const fieldOrder = { 'req-test': { Requirement: ['System.NodeName', 'Custom.CustomerRequirementId'] } };
+    const queries = {
+      'req-test': { columns: [{ referenceName: 'Custom.CustomerRequirementId', name: 'CustomerRequirementId' }] },
+    };
+
+    const drift = describeColumnDrift(fieldsByQuery, queries, fieldOrder, {}, {});
+
+    expect(drift.dropped).toEqual([{ label: 'CustomerRequirementId', wasRenamed: false, wasHidden: false }]);
+    expect(drift.added).toEqual([]);
+  });
+
+  test('falls back to the raw referenceName when no prior name snapshot is available', () => {
+    const fieldsByQuery = {
+      'req-test': { Requirement: [], 'Test Case': [] },
+      'test-req': { Requirement: [], 'Test Case': [] },
+    };
+    const fieldOrder = { 'req-test': { Requirement: ['Custom.CustomerRequirementId'] } };
+
+    const drift = describeColumnDrift(fieldsByQuery, {}, fieldOrder, {}, {});
+
+    expect(drift.dropped).toEqual([{ label: 'Custom.CustomerRequirementId', wasRenamed: false, wasHidden: false }]);
+  });
+
+  test('reports dropped columns using a rename override when present, tagged as renamed', () => {
+    const fieldsByQuery = {
+      'req-test': { Requirement: [], 'Test Case': [] },
+      'test-req': { Requirement: [], 'Test Case': [] },
+    };
+    const fieldOrder = { 'req-test': { Requirement: ['CustomerRequirementId'] } };
+    const fieldDisplayMapping = { 'req-test': { Requirement: { CustomerRequirementId: 'Customer ID' } } };
+
+    const drift = describeColumnDrift(fieldsByQuery, {}, fieldOrder, fieldDisplayMapping, {});
+
+    expect(drift.dropped).toEqual([{ label: 'Customer ID', wasRenamed: true, wasHidden: false }]);
+  });
+
+  test('tags a dropped column that was hidden', () => {
+    const fieldsByQuery = {
+      'req-test': { Requirement: [], 'Test Case': [] },
+      'test-req': { Requirement: [], 'Test Case': [] },
+    };
+    const fieldOrder = { 'req-test': { Requirement: ['CustomerRequirementId'] } };
+    const fieldVisibility = { 'req-test': { Requirement: { CustomerRequirementId: false } } };
+
+    const drift = describeColumnDrift(fieldsByQuery, {}, fieldOrder, {}, fieldVisibility);
+
+    expect(drift.dropped).toEqual([{ label: 'CustomerRequirementId', wasRenamed: false, wasHidden: true }]);
+  });
+
+  test('does not flag ALWAYS_VISIBLE_REFS/EXCLUDED_FIELD_REFS as dropped — deriveFieldList excludes them by design, not because ADO removed them', () => {
+    const fieldsByQuery = {
+      'req-test': { Requirement: [{ referenceName: 'System.NodeName', name: 'Node Name' }], 'Test Case': [] },
+      'test-req': { Requirement: [], 'Test Case': [] },
+    };
+    // Legacy saved order containing System.Id (with an old rename) and System.WorkItemType —
+    // both are permanently excluded from fieldsByQuery, so they'd look "dropped" every time.
+    const fieldOrder = { 'req-test': { Requirement: ['System.NodeName', 'System.Id', 'System.WorkItemType'] } };
+    const fieldDisplayMapping = { 'req-test': { Requirement: { 'System.Id': 'System Id' } } };
+
+    const drift = describeColumnDrift(fieldsByQuery, {}, fieldOrder, fieldDisplayMapping, {});
+
+    expect(drift.dropped).toEqual([]);
+  });
+
+  test('reports added columns not present in saved fieldOrder', () => {
+    const fieldsByQuery = {
+      'req-test': {
+        Requirement: [
+          { referenceName: 'System.NodeName', name: 'Node Name' },
+          { referenceName: 'Microsoft.VSTS.Common.Severity', name: 'Severity' },
+        ],
+        'Test Case': [],
+      },
+      'test-req': { Requirement: [], 'Test Case': [] },
+    };
+    const fieldOrder = { 'req-test': { Requirement: ['System.NodeName'] } };
+
+    const drift = describeColumnDrift(fieldsByQuery, {}, fieldOrder, {}, {});
+
+    expect(drift.dropped).toEqual([]);
+    expect(drift.added).toEqual(['Severity']);
+  });
+
+  test('skips sides with no saved order (nothing to compare yet)', () => {
+    const fieldsByQuery = {
+      'req-test': { Requirement: [{ referenceName: 'System.NodeName', name: 'Node Name' }], 'Test Case': [] },
+      'test-req': { Requirement: [], 'Test Case': [] },
+    };
+
+    const drift = describeColumnDrift(fieldsByQuery, {}, {}, {}, {});
+
+    expect(drift).toEqual({ dropped: [], added: [] });
+  });
+});
+
+describe('formatColumnDriftMessage', () => {
+  test('returns null when nothing changed', () => {
+    expect(formatColumnDriftMessage({ dropped: [], added: [] })).toBeNull();
+  });
+
+  test('formats a combined removed/added sentence with the renamed tag', () => {
+    const message = formatColumnDriftMessage({
+      dropped: [{ label: 'Customer ID', wasRenamed: true, wasHidden: false }],
+      added: ['Severity'],
+    });
+    expect(message).toContain('removed Customer ID (was renamed)');
+    expect(message).toContain('added Severity');
+  });
+
+  test('does not add a "(was ...)" suffix for a dropped column with no prior customization', () => {
+    const message = formatColumnDriftMessage({
+      dropped: [{ label: 'CustomerRequirementId', wasRenamed: false, wasHidden: false }],
+      added: [],
+    });
+    expect(message).toContain('removed CustomerRequirementId');
+    expect(message).not.toContain('(was');
+  });
+
+  test('truncates long lists with a "+N more" suffix', () => {
+    const dropped = ['A', 'B', 'C', 'D', 'E', 'F'].map((label) => ({ label, wasRenamed: false, wasHidden: false }));
+    const message = formatColumnDriftMessage({ dropped, added: [] }, 4);
+    expect(message).toContain('A, B, C, D +2 more');
+  });
+
+  test('omits the save-again hint by default', () => {
+    const message = formatColumnDriftMessage({
+      dropped: [{ label: 'CustomerRequirementId', wasRenamed: false, wasHidden: false }],
+      added: [],
+    });
+    expect(message).not.toContain('Save this favorite again');
+  });
+
+  test('appends a save-again hint when the drift was auto-pruned locally (wasPruned=true)', () => {
+    const message = formatColumnDriftMessage(
+      { dropped: [{ label: 'CustomerRequirementId', wasRenamed: false, wasHidden: false }], added: [] },
+      4,
+      true
+    );
+    expect(message).toContain('Save this favorite again to keep this fix.');
+  });
+});
+
+describe('pruneStaleFieldConfig', () => {
+  const fieldsByQuery = {
+    'req-test': { Requirement: [{ referenceName: 'System.NodeName', name: 'Node Name' }], 'Test Case': [] },
+    'test-req': { Requirement: [], 'Test Case': [] },
+  };
+  const reqTestQuery = { id: 'q1' };
+
+  test('removes a dropped referenceName from fieldOrder, fieldVisibility, and fieldDisplayMapping', () => {
+    const fieldOrder = { 'req-test': { Requirement: ['System.NodeName', 'CustomerRequirementId'] } };
+    const fieldVisibility = { 'req-test': { Requirement: { CustomerRequirementId: false } } };
+    const fieldDisplayMapping = { 'req-test': { Requirement: { CustomerRequirementId: 'Customer ID' } } };
+
+    const result = pruneStaleFieldConfig(
+      fieldsByQuery,
+      { 'req-test': reqTestQuery },
+      fieldOrder,
+      fieldVisibility,
+      fieldDisplayMapping
+    );
+
+    expect(result.changed).toBe(true);
+    expect(result.fieldOrder['req-test'].Requirement).toEqual(['System.NodeName']);
+    expect(result.fieldVisibility['req-test'].Requirement).toEqual({});
+    expect(result.fieldDisplayMapping['req-test'].Requirement).toEqual({});
+  });
+
+  test('returns the original object references when nothing needs pruning (identity-stable)', () => {
+    const fieldOrder = { 'req-test': { Requirement: ['System.NodeName'] } };
+    const fieldVisibility = {};
+    const fieldDisplayMapping = {};
+
+    const result = pruneStaleFieldConfig(
+      fieldsByQuery,
+      { 'req-test': reqTestQuery },
+      fieldOrder,
+      fieldVisibility,
+      fieldDisplayMapping
+    );
+
+    expect(result.changed).toBe(false);
+    expect(result.fieldOrder).toBe(fieldOrder);
+    expect(result.fieldVisibility).toBe(fieldVisibility);
+    expect(result.fieldDisplayMapping).toBe(fieldDisplayMapping);
+  });
+
+  test('leaves an inactive direction (no query selected) untouched even if its saved refs look stale', () => {
+    const fieldOrder = { 'test-req': { Requirement: ['SomeStaleRef'] } };
+
+    const result = pruneStaleFieldConfig(
+      fieldsByQuery,
+      { 'req-test': reqTestQuery, 'test-req': null },
+      fieldOrder,
+      {},
+      {}
+    );
+
+    expect(result.changed).toBe(false);
+    expect(result.fieldOrder).toBe(fieldOrder);
+  });
+});

--- a/src/utils/traceColumnFields.js
+++ b/src/utils/traceColumnFields.js
@@ -1,0 +1,44 @@
+// ADO referenceNames + linked-mode pseudo-keys that are always shown and never dragged
+export const ALWAYS_VISIBLE_REFS = new Set(['System.Id', 'System.Title', 'Req ID', 'Test Case ID', 'Title']);
+export const EXCLUDED_FIELD_REFS = new Set(['System.WorkItemType']);
+
+// Locked columns in linked mode (only Customer ID is configurable)
+export const LINKED_REQ_COLUMNS = {
+  Requirement: [{ referenceName: 'Customer ID', name: 'Customer ID' }],
+  'Test Case': [],
+};
+
+// Returns { 'req-test': { Requirement, 'Test Case' }, 'test-req': { Requirement, 'Test Case' } }
+export function deriveFieldList(traceAnalysisMode, reqTestQuery, testReqQuery, columnMetadata) {
+  if (traceAnalysisMode === 'linkedRequirement') {
+    return { 'req-test': LINKED_REQ_COLUMNS, 'test-req': LINKED_REQ_COLUMNS };
+  }
+  if (traceAnalysisMode !== 'query') {
+    return { 'req-test': { Requirement: [], 'Test Case': [] }, 'test-req': { Requirement: [], 'Test Case': [] } };
+  }
+
+  const filterMeta = (cols) =>
+    (cols || []).filter(
+      (c) => c?.referenceName && !EXCLUDED_FIELD_REFS.has(c.referenceName) && !ALWAYS_VISIBLE_REFS.has(c.referenceName)
+    );
+
+  const resolveQuerySides = (queryKey) => {
+    const meta = columnMetadata?.[queryKey];
+    if (meta) {
+      return {
+        Requirement: filterMeta(meta.Requirement),
+        'Test Case': filterMeta(meta['Test Case']),
+      };
+    }
+    // Not yet fetched (or fetch failed): empty for both sides. Never fall back to the query's
+    // raw declared columns here — that list isn't split by WIT type, and handing the same
+    // unfiltered array to both Requirement and Test Case lets a Requirement-only column get
+    // seeded into Test Case's saved fieldOrder if the dialog is used before this resolves.
+    return { Requirement: [], 'Test Case': [] };
+  };
+
+  return {
+    'req-test': resolveQuerySides('req-test'),
+    'test-req': resolveQuerySides('test-req'),
+  };
+}

--- a/src/utils/traceColumnFields.test.js
+++ b/src/utils/traceColumnFields.test.js
@@ -1,0 +1,72 @@
+import { describe, expect, test } from 'vitest';
+import { deriveFieldList } from './traceColumnFields';
+
+describe('deriveFieldList', () => {
+  test('returns empty arrays for both sides when columnMetadata has no entry for a query (loading / failed fetch)', () => {
+    const reqTestQuery = {
+      columns: [
+        { referenceName: 'System.Id', name: 'ID' },
+        { referenceName: 'Custom.CustomerRequirementId', name: 'CustomerRequirementId' },
+      ],
+    };
+
+    const result = deriveFieldList('query', reqTestQuery, null, {});
+
+    // Must not fall back to the query's raw declared columns — that list isn't split by WIT
+    // type, and handing it to both sides is exactly what seeded a Requirement-only column into
+    // Test Case's saved fieldOrder.
+    expect(result['req-test']).toEqual({ Requirement: [], 'Test Case': [] });
+    expect(result['test-req']).toEqual({ Requirement: [], 'Test Case': [] });
+  });
+
+  test('uses columnMetadata, split per side, once it has loaded', () => {
+    const columnMetadata = {
+      'req-test': {
+        Requirement: [
+          { referenceName: 'System.AssignedTo', name: 'Assigned To' },
+          { referenceName: 'Custom.CustomerRequirementId', name: 'CustomerRequirementId' },
+        ],
+        'Test Case': [{ referenceName: 'System.AssignedTo', name: 'Assigned To' }],
+      },
+    };
+
+    const result = deriveFieldList('query', {}, null, columnMetadata);
+
+    const reqRefs = result['req-test'].Requirement.map((f) => f.referenceName);
+    const tcRefs = result['req-test']['Test Case'].map((f) => f.referenceName);
+    expect(reqRefs).toContain('Custom.CustomerRequirementId');
+    expect(tcRefs).not.toContain('Custom.CustomerRequirementId');
+  });
+
+  test('filters ALWAYS_VISIBLE_REFS and EXCLUDED_FIELD_REFS out of columnMetadata results', () => {
+    const columnMetadata = {
+      'req-test': {
+        Requirement: [
+          { referenceName: 'System.Id', name: 'ID' },
+          { referenceName: 'System.WorkItemType', name: 'Work Item Type' },
+          { referenceName: 'System.Title', name: 'Title' },
+          { referenceName: 'System.State', name: 'State' },
+        ],
+        'Test Case': [],
+      },
+    };
+
+    const result = deriveFieldList('query', {}, null, columnMetadata);
+
+    expect(result['req-test'].Requirement.map((f) => f.referenceName)).toEqual(['System.State']);
+  });
+
+  test('linkedRequirement mode returns the fixed Customer ID pseudo-column, ignoring columnMetadata', () => {
+    const result = deriveFieldList('linkedRequirement', {}, {}, {});
+    expect(result['req-test'].Requirement).toEqual([{ referenceName: 'Customer ID', name: 'Customer ID' }]);
+    expect(result['req-test']['Test Case']).toEqual([]);
+  });
+
+  test('non-query, non-linkedRequirement mode returns empty for everything', () => {
+    const result = deriveFieldList('none', {}, {}, {});
+    expect(result).toEqual({
+      'req-test': { Requirement: [], 'Test Case': [] },
+      'test-req': { Requirement: [], 'Test Case': [] },
+    });
+  });
+});


### PR DESCRIPTION
- Refetch columns on Column Settings dialog open + manual refresh button,
  with a loading skeleton and generation-counter guard against stale
  in-flight responses overwriting newer state (TestContentSelector,
  DetailedStepsSettingsDialog, FieldDisplayMappingDialog).
- Detect and toast when a loaded favorite's saved column config drifted
  from ADO's current columns (added/removed), naming the actual column
  and what customization is lost (renamed/hidden), not just a count.
- Auto-prune stale rename/hide/order entries for columns no longer in
  ADO so the "pending changes" badge doesn't count dead references
  forever; append a "save this favorite again" hint when pruning
  silently fixed something the DB copy still has.
- Fix root cause of false "column removed" reports: the column-list
  fallback (used while columnMetadata is still loading) handed the
  same unfiltered list to both Requirement and Test Case, letting a
  Requirement-only column get seeded into Test Case's saved fieldOrder.
  Fallback now returns empty for both sides instead.