### PR TITLE
#298810 - Render Trace Analysis column drift toast as a structured li…

### DIFF
--- a/src/components/common/ColumnDriftToast.jsx
+++ b/src/components/common/ColumnDriftToast.jsx
@@ -1,0 +1,61 @@
+import { Box, Typography } from '@mui/material';
+
+// Renders a describeColumnDrift() result as a toast body — a plain sentence gets unreadable once
+// there are more than a couple of changed columns, so this lists them instead, each on its own
+// line, with the dropped/added sections independently scrollable if long.
+const ColumnDriftToast = ({ drift, wasPruned = false }) => {
+  const { dropped, added } = drift;
+
+  const describeDropped = (d) => {
+    const tags = [];
+    if (d.wasRenamed) tags.push('renamed');
+    if (d.wasHidden) tags.push('hidden');
+    return tags.length ? `${d.label} (was ${tags.join(', ')})` : d.label;
+  };
+
+  return (
+    <Box sx={{ maxWidth: 320 }}>
+      <Typography variant='body2' sx={{ fontWeight: 600, mb: 0.5 }}>
+        Trace Analysis columns changed in ADO since this favorite was saved
+      </Typography>
+
+      {dropped.length > 0 && (
+        <Box sx={{ mb: added.length > 0 ? 1 : 0.5 }}>
+          <Typography variant='caption' color='text.secondary' sx={{ display: 'block', fontWeight: 600 }}>
+            Removed ({dropped.length})
+          </Typography>
+          <Box component='ul' sx={{ m: 0, pl: 2.5, maxHeight: 140, overflowY: 'auto' }}>
+            {dropped.map((d) => (
+              <Typography key={d.label} component='li' variant='caption' sx={{ lineHeight: 1.6 }}>
+                {describeDropped(d)}
+              </Typography>
+            ))}
+          </Box>
+        </Box>
+      )}
+
+      {added.length > 0 && (
+        <Box sx={{ mb: wasPruned ? 1 : 0.5 }}>
+          <Typography variant='caption' color='text.secondary' sx={{ display: 'block', fontWeight: 600 }}>
+            Added ({added.length})
+          </Typography>
+          <Box component='ul' sx={{ m: 0, pl: 2.5, maxHeight: 140, overflowY: 'auto' }}>
+            {added.map((name) => (
+              <Typography key={name} component='li' variant='caption' sx={{ lineHeight: 1.6 }}>
+                {name}
+              </Typography>
+            ))}
+          </Box>
+        </Box>
+      )}
+
+      {wasPruned && (
+        <Typography variant='caption' sx={{ fontStyle: 'italic', display: 'block' }}>
+          Save this favorite again to keep this fix.
+        </Typography>
+      )}
+    </Box>
+  );
+};
+
+export default ColumnDriftToast;

--- a/src/components/common/ColumnDriftToast.test.jsx
+++ b/src/components/common/ColumnDriftToast.test.jsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, test } from 'vitest';
+import ColumnDriftToast from './ColumnDriftToast';
+
+describe('ColumnDriftToast', () => {
+  test('lists dropped columns with their rename/hidden tags', () => {
+    const drift = {
+      dropped: [
+        { label: 'Customer ID', wasRenamed: true, wasHidden: false },
+        { label: 'Severity', wasRenamed: false, wasHidden: true },
+      ],
+      added: [],
+    };
+
+    const markup = renderToStaticMarkup(<ColumnDriftToast drift={drift} />);
+
+    expect(markup).toContain('Removed (2)');
+    expect(markup).toContain('Customer ID (was renamed)');
+    expect(markup).toContain('Severity (was hidden)');
+    expect(markup).not.toContain('Save this favorite again');
+  });
+
+  test('lists added columns and shows the save-again hint when wasPruned is true', () => {
+    const drift = { dropped: [], added: ['Node Name', 'Priority'] };
+
+    const markup = renderToStaticMarkup(<ColumnDriftToast drift={drift} wasPruned />);
+
+    expect(markup).toContain('Added (2)');
+    expect(markup).toContain('Node Name');
+    expect(markup).toContain('Priority');
+    expect(markup).toContain('Save this favorite again to keep this fix.');
+  });
+
+  test('renders no list sections when both dropped and added are empty', () => {
+    const markup = renderToStaticMarkup(<ColumnDriftToast drift={{ dropped: [], added: [] }} />);
+
+    expect(markup).not.toContain('Removed');
+    expect(markup).not.toContain('Added');
+  });
+});

--- a/src/components/common/table/TestContentSelector.jsx
+++ b/src/components/common/table/TestContentSelector.jsx
@@ -33,7 +33,8 @@ import { suiteIdCollection } from '../../../utils/sessionPersistence';
 import useTabStatePersistence from '../../../hooks/useTabStatePersistence';
 import RestoreBackdrop from '../RestoreBackdrop';
 import { buildTestContentRequestData } from './testContentRequestData';
-import { describeColumnDrift, formatColumnDriftMessage, pruneStaleFieldConfig } from '../../../utils/columnDrift';
+import { describeColumnDrift, hasColumnDrift, pruneStaleFieldConfig } from '../../../utils/columnDrift';
+import ColumnDriftToast from '../ColumnDriftToast';
 
 const defaultSelectedQueries = {
   traceAnalysisMode: 'none',
@@ -476,8 +477,9 @@ const TestContentSelector = observer(
         if (pendingFavoriteColumnCheckRef.current) {
           pendingFavoriteColumnCheckRef.current = false;
           const drift = describeColumnDrift(fieldsByQuery, queries, current.fieldOrder, current.fieldDisplayMapping, current.fieldVisibility);
-          const message = formatColumnDriftMessage(drift, 4, pruned.changed);
-          if (message) toast.info(message);
+          if (hasColumnDrift(drift)) {
+            toast.info(<ColumnDriftToast drift={drift} wasPruned={pruned.changed} />, { autoClose: 10000 });
+          }
         }
 
         setTraceAnalysisRequest((prev) => ({

--- a/src/components/dialogs/DetailedStepsSettingsDialog.jsx
+++ b/src/components/dialogs/DetailedStepsSettingsDialog.jsx
@@ -28,9 +28,10 @@ import React, { useState, useEffect, useCallback, useRef } from 'react';
 import { toast } from 'react-toastify';
 import QueryTree from '../common/QueryTree';
 import OverlayLoader from '../common/OverlayLoader';
+import ColumnDriftToast from '../common/ColumnDriftToast';
 import FieldDisplayMappingDialog from './FieldDisplayMappingDialog';
 import { deriveFieldList } from '../../utils/traceColumnFields';
-import { describeColumnDrift, formatColumnDriftMessage, pruneStaleFieldConfig } from '../../utils/columnDrift';
+import { describeColumnDrift, hasColumnDrift, pruneStaleFieldConfig } from '../../utils/columnDrift';
 
 const DetailedStepsSettingsDialog = ({
   store,
@@ -92,8 +93,9 @@ const DetailedStepsSettingsDialog = ({
       if (pendingFavoriteColumnCheckRef.current) {
         pendingFavoriteColumnCheckRef.current = false;
         const drift = describeColumnDrift(fieldsByQuery, queries, fieldOrder, fieldDisplayMapping, fieldVisibility);
-        const message = formatColumnDriftMessage(drift, 4, pruned.changed);
-        if (message) toast.info(message);
+        if (hasColumnDrift(drift)) {
+          toast.info(<ColumnDriftToast drift={drift} wasPruned={pruned.changed} />, { autoClose: 10000 });
+        }
       }
 
       setStepExecutionState((prev) => ({

--- a/src/utils/columnDrift.js
+++ b/src/utils/columnDrift.js
@@ -53,30 +53,9 @@ export function describeColumnDrift(fieldsByQuery, queries, fieldOrder, fieldDis
   };
 }
 
-// Formats a drift result into a single human-readable sentence, truncating long lists.
-// wasPruned: true when pruneStaleFieldConfig actually changed something for this refresh — the
-// local session state is already fixed, but the favorite in the DB still has the stale entry
-// until the user explicitly saves again, so we tell them that instead of leaving them confused
-// about why the same "removed" toast keeps recurring on this favorite.
-export function formatColumnDriftMessage({ dropped, added }, maxPerList = 4, wasPruned = false) {
-  if (dropped.length === 0 && added.length === 0) return null;
-
-  const describeDropped = (d) => {
-    const tags = [];
-    if (d.wasRenamed) tags.push('renamed');
-    if (d.wasHidden) tags.push('hidden');
-    return tags.length ? `${d.label} (was ${tags.join(', ')})` : d.label;
-  };
-  const truncate = (list, formatter) =>
-    list.length > maxPerList
-      ? `${list.slice(0, maxPerList).map(formatter).join(', ')} +${list.length - maxPerList} more`
-      : list.map(formatter).join(', ');
-
-  const parts = [];
-  if (dropped.length) parts.push(`removed ${truncate(dropped, describeDropped)}`);
-  if (added.length) parts.push(`added ${truncate(added, (x) => x)}`);
-  const base = `Trace Analysis columns changed in ADO since this favorite was saved (${parts.join('; ')}).`;
-  return wasPruned ? `${base} Save this favorite again to keep this fix.` : base;
+// True when a drift result has anything worth showing to the user.
+export function hasColumnDrift({ dropped, added }) {
+  return dropped.length > 0 || added.length > 0;
 }
 
 // Removes referenceNames from saved fieldOrder/fieldVisibility/fieldDisplayMapping that no

--- a/src/utils/columnDrift.test.js
+++ b/src/utils/columnDrift.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'vitest';
-import { describeColumnDrift, formatColumnDriftMessage, pruneStaleFieldConfig } from './columnDrift';
+import { describeColumnDrift, hasColumnDrift, pruneStaleFieldConfig } from './columnDrift';
 
 describe('describeColumnDrift', () => {
   test('resolves a dropped column label from the query\'s prior columns snapshot when no rename exists', () => {
@@ -102,50 +102,17 @@ describe('describeColumnDrift', () => {
   });
 });
 
-describe('formatColumnDriftMessage', () => {
-  test('returns null when nothing changed', () => {
-    expect(formatColumnDriftMessage({ dropped: [], added: [] })).toBeNull();
+describe('hasColumnDrift', () => {
+  test('false when both lists are empty', () => {
+    expect(hasColumnDrift({ dropped: [], added: [] })).toBe(false);
   });
 
-  test('formats a combined removed/added sentence with the renamed tag', () => {
-    const message = formatColumnDriftMessage({
-      dropped: [{ label: 'Customer ID', wasRenamed: true, wasHidden: false }],
-      added: ['Severity'],
-    });
-    expect(message).toContain('removed Customer ID (was renamed)');
-    expect(message).toContain('added Severity');
+  test('true when there are dropped columns', () => {
+    expect(hasColumnDrift({ dropped: [{ label: 'X', wasRenamed: false, wasHidden: false }], added: [] })).toBe(true);
   });
 
-  test('does not add a "(was ...)" suffix for a dropped column with no prior customization', () => {
-    const message = formatColumnDriftMessage({
-      dropped: [{ label: 'CustomerRequirementId', wasRenamed: false, wasHidden: false }],
-      added: [],
-    });
-    expect(message).toContain('removed CustomerRequirementId');
-    expect(message).not.toContain('(was');
-  });
-
-  test('truncates long lists with a "+N more" suffix', () => {
-    const dropped = ['A', 'B', 'C', 'D', 'E', 'F'].map((label) => ({ label, wasRenamed: false, wasHidden: false }));
-    const message = formatColumnDriftMessage({ dropped, added: [] }, 4);
-    expect(message).toContain('A, B, C, D +2 more');
-  });
-
-  test('omits the save-again hint by default', () => {
-    const message = formatColumnDriftMessage({
-      dropped: [{ label: 'CustomerRequirementId', wasRenamed: false, wasHidden: false }],
-      added: [],
-    });
-    expect(message).not.toContain('Save this favorite again');
-  });
-
-  test('appends a save-again hint when the drift was auto-pruned locally (wasPruned=true)', () => {
-    const message = formatColumnDriftMessage(
-      { dropped: [{ label: 'CustomerRequirementId', wasRenamed: false, wasHidden: false }], added: [] },
-      4,
-      true
-    );
-    expect(message).toContain('Save this favorite again to keep this fix.');
+  test('true when there are added columns', () => {
+    expect(hasColumnDrift({ dropped: [], added: ['Severity'] })).toBe(true);
   });
 });
 


### PR DESCRIPTION
…st, not a sentence

A single truncated sentence ("removed X, Y, Z +N more; added A, B") becomes unreadable once several columns changed. Replace it with a JSX toast body (ColumnDriftToast) that lists Removed/Added columns each on their own line, independently scrollable, with rename/hidden tags kept inline — no more truncation needed. Drop the now-unused plain-text formatColumnDriftMessage in favor of a small hasColumnDrift() gate, since nothing else consumed the string form.