### PR TITLE
#298810 - Group Trace Analysis column drift toast by query direction

### DIFF
--- a/src/components/common/ColumnDriftToast.jsx
+++ b/src/components/common/ColumnDriftToast.jsx
@@ -1,56 +1,67 @@
-import { Box, Typography } from '@mui/material';
+import { Box, Divider, Typography } from '@mui/material';
 
-// Renders a describeColumnDrift() result as a toast body — a plain sentence gets unreadable once
-// there are more than a couple of changed columns, so this lists them instead, each on its own
-// line, with the dropped/added sections independently scrollable if long.
+const describeDropped = (d) => {
+  const tags = [];
+  if (d.wasRenamed) tags.push('renamed');
+  if (d.wasHidden) tags.push('hidden');
+  const base = `${d.label} (${d.side})`;
+  return tags.length ? `${base} — was ${tags.join(', ')}` : base;
+};
+
+// Renders a describeColumnDrift() result as a toast body, grouped by query direction (using the
+// query's own title, e.g. "Req-Test") so the user knows exactly which query a change came from
+// instead of guessing — the root-cause bugs behind this feature were always "wrong query" or
+// "wrong side" mixups, so surfacing that is the whole point, not an afterthought.
 const ColumnDriftToast = ({ drift, wasPruned = false }) => {
-  const { dropped, added } = drift;
-
-  const describeDropped = (d) => {
-    const tags = [];
-    if (d.wasRenamed) tags.push('renamed');
-    if (d.wasHidden) tags.push('hidden');
-    return tags.length ? `${d.label} (was ${tags.join(', ')})` : d.label;
-  };
+  const queryEntries = Object.entries(drift);
 
   return (
-    <Box sx={{ maxWidth: 320 }}>
+    <Box sx={{ maxWidth: 340 }}>
       <Typography variant='body2' sx={{ fontWeight: 600, mb: 0.5 }}>
         Trace Analysis columns changed in ADO since this favorite was saved
       </Typography>
 
-      {dropped.length > 0 && (
-        <Box sx={{ mb: added.length > 0 ? 1 : 0.5 }}>
-          <Typography variant='caption' color='text.secondary' sx={{ display: 'block', fontWeight: 600 }}>
-            Removed ({dropped.length})
+      {queryEntries.map(([queryKey, { title, dropped, added }], i) => (
+        <Box key={queryKey} sx={{ mt: i > 0 ? 1 : 0 }}>
+          {i > 0 && <Divider sx={{ mb: 1 }} />}
+          <Typography variant='caption' sx={{ display: 'block', fontWeight: 700 }}>
+            {title}
           </Typography>
-          <Box component='ul' sx={{ m: 0, pl: 2.5, maxHeight: 140, overflowY: 'auto' }}>
-            {dropped.map((d) => (
-              <Typography key={d.label} component='li' variant='caption' sx={{ lineHeight: 1.6 }}>
-                {describeDropped(d)}
-              </Typography>
-            ))}
-          </Box>
-        </Box>
-      )}
 
-      {added.length > 0 && (
-        <Box sx={{ mb: wasPruned ? 1 : 0.5 }}>
-          <Typography variant='caption' color='text.secondary' sx={{ display: 'block', fontWeight: 600 }}>
-            Added ({added.length})
-          </Typography>
-          <Box component='ul' sx={{ m: 0, pl: 2.5, maxHeight: 140, overflowY: 'auto' }}>
-            {added.map((name) => (
-              <Typography key={name} component='li' variant='caption' sx={{ lineHeight: 1.6 }}>
-                {name}
+          {dropped.length > 0 && (
+            <Box sx={{ mb: added.length > 0 ? 0.75 : 0.25 }}>
+              <Typography variant='caption' color='text.secondary' sx={{ display: 'block', fontWeight: 600 }}>
+                Removed ({dropped.length})
               </Typography>
-            ))}
-          </Box>
+              <Box component='ul' sx={{ m: 0, pl: 2.5, maxHeight: 140, overflowY: 'auto' }}>
+                {dropped.map((d) => (
+                  <Typography key={`${d.side}:${d.label}`} component='li' variant='caption' sx={{ lineHeight: 1.6 }}>
+                    {describeDropped(d)}
+                  </Typography>
+                ))}
+              </Box>
+            </Box>
+          )}
+
+          {added.length > 0 && (
+            <Box>
+              <Typography variant='caption' color='text.secondary' sx={{ display: 'block', fontWeight: 600 }}>
+                Added ({added.length})
+              </Typography>
+              <Box component='ul' sx={{ m: 0, pl: 2.5, maxHeight: 140, overflowY: 'auto' }}>
+                {added.map((a) => (
+                  <Typography key={`${a.side}:${a.label}`} component='li' variant='caption' sx={{ lineHeight: 1.6 }}>
+                    {a.label} ({a.side})
+                  </Typography>
+                ))}
+              </Box>
+            </Box>
+          )}
         </Box>
-      )}
+      ))}
 
       {wasPruned && (
-        <Typography variant='caption' sx={{ fontStyle: 'italic', display: 'block' }}>
+        <Typography variant='caption' sx={{ fontStyle: 'italic', display: 'block', mt: 1 }}>
           Save this favorite again to keep this fix.
         </Typography>
       )}

--- a/src/components/common/ColumnDriftToast.test.jsx
+++ b/src/components/common/ColumnDriftToast.test.jsx
@@ -4,37 +4,49 @@ import { describe, expect, test } from 'vitest';
 import ColumnDriftToast from './ColumnDriftToast';
 
 describe('ColumnDriftToast', () => {
-  test('lists dropped columns with their rename/hidden tags', () => {
+  test('shows the query title as a group heading, and tags each entry with its side', () => {
     const drift = {
-      dropped: [
-        { label: 'Customer ID', wasRenamed: true, wasHidden: false },
-        { label: 'Severity', wasRenamed: false, wasHidden: true },
-      ],
-      added: [],
+      'req-test': {
+        title: 'Req-Test',
+        dropped: [{ label: 'Customer ID', side: 'Test Case', wasRenamed: false, wasHidden: true }],
+        added: [],
+      },
     };
 
     const markup = renderToStaticMarkup(<ColumnDriftToast drift={drift} />);
 
-    expect(markup).toContain('Removed (2)');
-    expect(markup).toContain('Customer ID (was renamed)');
-    expect(markup).toContain('Severity (was hidden)');
-    expect(markup).not.toContain('Save this favorite again');
+    expect(markup).toContain('Req-Test');
+    expect(markup).toContain('Removed (1)');
+    expect(markup).toContain('Customer ID (Test Case)');
+    expect(markup).toContain('was hidden');
   });
 
-  test('lists added columns and shows the save-again hint when wasPruned is true', () => {
-    const drift = { dropped: [], added: ['Node Name', 'Priority'] };
+  test('renders a separate group per query key', () => {
+    const drift = {
+      'req-test': { title: 'Req-Test', dropped: [], added: [{ label: 'Severity', side: 'Requirement' }] },
+      'test-req': { title: 'Test-Req', dropped: [{ label: 'Priority', side: 'Test Case', wasRenamed: false, wasHidden: false }], added: [] },
+    };
 
-    const markup = renderToStaticMarkup(<ColumnDriftToast drift={drift} wasPruned />);
+    const markup = renderToStaticMarkup(<ColumnDriftToast drift={drift} />);
 
-    expect(markup).toContain('Added (2)');
-    expect(markup).toContain('Node Name');
-    expect(markup).toContain('Priority');
-    expect(markup).toContain('Save this favorite again to keep this fix.');
+    expect(markup).toContain('Req-Test');
+    expect(markup).toContain('Severity (Requirement)');
+    expect(markup).toContain('Test-Req');
+    expect(markup).toContain('Priority (Test Case)');
   });
 
-  test('renders no list sections when both dropped and added are empty', () => {
-    const markup = renderToStaticMarkup(<ColumnDriftToast drift={{ dropped: [], added: [] }} />);
+  test('shows the save-again hint when wasPruned is true, omits it otherwise', () => {
+    const drift = { 'req-test': { title: 'Req-Test', dropped: [], added: [{ label: 'X', side: 'Requirement' }] } };
 
+    const withHint = renderToStaticMarkup(<ColumnDriftToast drift={drift} wasPruned />);
+    const withoutHint = renderToStaticMarkup(<ColumnDriftToast drift={drift} />);
+
+    expect(withHint).toContain('Save this favorite again to keep this fix.');
+    expect(withoutHint).not.toContain('Save this favorite again');
+  });
+
+  test('renders no query groups when drift is empty', () => {
+    const markup = renderToStaticMarkup(<ColumnDriftToast drift={{}} />);
     expect(markup).not.toContain('Removed');
     expect(markup).not.toContain('Added');
   });

--- a/src/utils/columnDrift.js
+++ b/src/utils/columnDrift.js
@@ -1,61 +1,64 @@
 import { ALWAYS_VISIBLE_REFS, EXCLUDED_FIELD_REFS } from './traceColumnFields';
 
+const QUERY_KEY_FALLBACK_LABEL = { 'req-test': 'Req → Test Case', 'test-req': 'Test Case → Req' };
+
 // Compares a saved per-query per-side column config (e.g. from a favorite) against the
 // currently live columns (fresh from ADO) and reports which referenceNames were dropped
-// (saved but no longer present) and which were added (present but never saved).
+// (saved but no longer present) and which were added (present but never saved), grouped by
+// query direction — the actual bugs behind this feature were always "wrong query" or "wrong
+// side" mixups, so which query/side a change belongs to is exactly what the user needs to
+// diagnose it, not just a flat list of column names.
 // `fieldsByQuery` shape: { [queryKey]: { [side]: [{ referenceName, name }] } } — see deriveFieldList.
-// `queries` shape: { [queryKey]: query } where query.columns is the {referenceName, name}[]
-// snapshot captured when the query was selected — the only place we can still recover a dropped
-// column's friendly name, since it's no longer in the fresh fetch by definition.
-// Dropped entries carry the display label (rename override, else the query's own prior name for
-// that column, else referenceName as a last resort) plus which customizations are being
-// discarded (renamed / hidden), so the caller can say more than just "a column was removed".
+// `queries` shape: { [queryKey]: query } where query.title is shown as the group heading and
+// query.columns is the {referenceName, name}[] snapshot captured when the query was selected —
+// the only place we can still recover a dropped column's friendly name, since it's no longer in
+// the fresh fetch by definition.
+// Returns: { [queryKey]: { title, dropped: [{label, side, wasRenamed, wasHidden}], added: [{label, side}] } }
+// — only query keys with at least one dropped/added entry are included.
 export function describeColumnDrift(fieldsByQuery, queries, fieldOrder, fieldDisplayMapping, fieldVisibility) {
-  const droppedByLabel = new Map(); // label -> { wasRenamed, wasHidden }
-  const addedByLabel = new Set();
+  const result = {};
 
   for (const [queryKey, sides] of Object.entries(fieldsByQuery || {})) {
     const priorNameByRef = new Map((queries?.[queryKey]?.columns || []).map((c) => [c.referenceName, c.name]));
+    const dropped = [];
+    const added = [];
 
     for (const [side, fields] of Object.entries(sides || {})) {
       const savedRefs = fieldOrder?.[queryKey]?.[side] || [];
-      if (savedRefs.length === 0) continue; // no saved config for this side yet
-
       const currentByRef = new Map((fields || []).map((f) => [f.referenceName, f.name]));
-      for (const ref of savedRefs) {
-        if (currentByRef.has(ref)) continue;
-        // Fields that are deliberately excluded from fieldsByQuery (System.Id, Work Item Type,
-        // etc.) will never appear in currentByRef even though ADO didn't actually drop them —
-        // a legacy saved entry for one of these (e.g. from before this exclusion existed) is
-        // noise, not real drift.
-        if (ALWAYS_VISIBLE_REFS.has(ref) || EXCLUDED_FIELD_REFS.has(ref)) continue;
 
-        const override = fieldDisplayMapping?.[queryKey]?.[side]?.[ref];
-        const wasHidden = fieldVisibility?.[queryKey]?.[side]?.[ref] === false;
-        const label = override || priorNameByRef.get(ref) || ref;
-        const existing = droppedByLabel.get(label) || { wasRenamed: false, wasHidden: false };
-        droppedByLabel.set(label, {
-          wasRenamed: existing.wasRenamed || Boolean(override),
-          wasHidden: existing.wasHidden || wasHidden,
-        });
-      }
+      if (savedRefs.length > 0) {
+        for (const ref of savedRefs) {
+          if (currentByRef.has(ref)) continue;
+          // Fields that are deliberately excluded from fieldsByQuery (System.Id, Work Item
+          // Type, etc.) will never appear in currentByRef even though ADO didn't actually drop
+          // them — a legacy saved entry for one of these (e.g. from before this exclusion
+          // existed) is noise, not real drift.
+          if (ALWAYS_VISIBLE_REFS.has(ref) || EXCLUDED_FIELD_REFS.has(ref)) continue;
 
-      const savedSet = new Set(savedRefs);
-      for (const [ref, name] of currentByRef) {
-        if (!savedSet.has(ref)) addedByLabel.add(name || ref);
+          const override = fieldDisplayMapping?.[queryKey]?.[side]?.[ref];
+          const wasHidden = fieldVisibility?.[queryKey]?.[side]?.[ref] === false;
+          dropped.push({ label: override || priorNameByRef.get(ref) || ref, side, wasRenamed: Boolean(override), wasHidden });
+        }
+
+        const savedSet = new Set(savedRefs);
+        for (const [ref, name] of currentByRef) {
+          if (!savedSet.has(ref)) added.push({ label: name || ref, side });
+        }
       }
+    }
+
+    if (dropped.length > 0 || added.length > 0) {
+      result[queryKey] = { title: queries?.[queryKey]?.title || QUERY_KEY_FALLBACK_LABEL[queryKey] || queryKey, dropped, added };
     }
   }
 
-  return {
-    dropped: [...droppedByLabel.entries()].map(([label, info]) => ({ label, ...info })),
-    added: [...addedByLabel],
-  };
+  return result;
 }
 
-// True when a drift result has anything worth showing to the user.
-export function hasColumnDrift({ dropped, added }) {
-  return dropped.length > 0 || added.length > 0;
+// True when a describeColumnDrift() result has anything worth showing to the user.
+export function hasColumnDrift(drift) {
+  return Object.keys(drift || {}).length > 0;
 }
 
 // Removes referenceNames from saved fieldOrder/fieldVisibility/fieldDisplayMapping that no

--- a/src/utils/columnDrift.test.js
+++ b/src/utils/columnDrift.test.js
@@ -2,6 +2,47 @@ import { describe, expect, test } from 'vitest';
 import { describeColumnDrift, hasColumnDrift, pruneStaleFieldConfig } from './columnDrift';
 
 describe('describeColumnDrift', () => {
+  test('groups results by query key, using the query title as the group heading', () => {
+    const fieldsByQuery = {
+      'req-test': { Requirement: [], 'Test Case': [] },
+      'test-req': { Requirement: [], 'Test Case': [] },
+    };
+    const fieldOrder = { 'req-test': { Requirement: ['Custom.CustomerRequirementId'] } };
+    const queries = { 'req-test': { title: 'Req-Test', columns: [] } };
+
+    const drift = describeColumnDrift(fieldsByQuery, queries, fieldOrder, {}, {});
+
+    expect(Object.keys(drift)).toEqual(['req-test']);
+    expect(drift['req-test'].title).toBe('Req-Test');
+  });
+
+  test('falls back to a generic direction label when the query has no title', () => {
+    const fieldsByQuery = { 'req-test': { Requirement: [], 'Test Case': [] }, 'test-req': { Requirement: [], 'Test Case': [] } };
+    const fieldOrder = { 'test-req': { Requirement: ['Custom.CustomerRequirementId'] } };
+
+    const drift = describeColumnDrift(fieldsByQuery, {}, fieldOrder, {}, {});
+
+    expect(drift['test-req'].title).toBe('Test Case → Req');
+  });
+
+  test('tags each dropped/added entry with its side, so a cross-side ghost is distinguishable', () => {
+    const fieldsByQuery = {
+      'req-test': { Requirement: [{ referenceName: 'Custom.CustomerID', name: 'Customer ID' }], 'Test Case': [] },
+      'test-req': { Requirement: [], 'Test Case': [] },
+    };
+    // Saved as hidden under Test Case even though it's only valid on Requirement — the exact
+    // cross-side ghost bug this feature exists to surface.
+    const fieldOrder = { 'req-test': { 'Test Case': ['Custom.CustomerID'] } };
+    const fieldVisibility = { 'req-test': { 'Test Case': { 'Custom.CustomerID': false } } };
+    const queries = { 'req-test': { title: 'Req-Test' } };
+
+    const drift = describeColumnDrift(fieldsByQuery, queries, fieldOrder, {}, fieldVisibility);
+
+    expect(drift['req-test'].dropped).toEqual([
+      { label: 'Custom.CustomerID', side: 'Test Case', wasRenamed: false, wasHidden: true },
+    ]);
+  });
+
   test('resolves a dropped column label from the query\'s prior columns snapshot when no rename exists', () => {
     const fieldsByQuery = {
       'req-test': { Requirement: [{ referenceName: 'System.NodeName', name: 'Node Name' }], 'Test Case': [] },
@@ -14,8 +55,9 @@ describe('describeColumnDrift', () => {
 
     const drift = describeColumnDrift(fieldsByQuery, queries, fieldOrder, {}, {});
 
-    expect(drift.dropped).toEqual([{ label: 'CustomerRequirementId', wasRenamed: false, wasHidden: false }]);
-    expect(drift.added).toEqual([]);
+    expect(drift['req-test'].dropped).toEqual([
+      { label: 'CustomerRequirementId', side: 'Requirement', wasRenamed: false, wasHidden: false },
+    ]);
   });
 
   test('falls back to the raw referenceName when no prior name snapshot is available', () => {
@@ -27,7 +69,7 @@ describe('describeColumnDrift', () => {
 
     const drift = describeColumnDrift(fieldsByQuery, {}, fieldOrder, {}, {});
 
-    expect(drift.dropped).toEqual([{ label: 'Custom.CustomerRequirementId', wasRenamed: false, wasHidden: false }]);
+    expect(drift['req-test'].dropped[0].label).toBe('Custom.CustomerRequirementId');
   });
 
   test('reports dropped columns using a rename override when present, tagged as renamed', () => {
@@ -40,20 +82,9 @@ describe('describeColumnDrift', () => {
 
     const drift = describeColumnDrift(fieldsByQuery, {}, fieldOrder, fieldDisplayMapping, {});
 
-    expect(drift.dropped).toEqual([{ label: 'Customer ID', wasRenamed: true, wasHidden: false }]);
-  });
-
-  test('tags a dropped column that was hidden', () => {
-    const fieldsByQuery = {
-      'req-test': { Requirement: [], 'Test Case': [] },
-      'test-req': { Requirement: [], 'Test Case': [] },
-    };
-    const fieldOrder = { 'req-test': { Requirement: ['CustomerRequirementId'] } };
-    const fieldVisibility = { 'req-test': { Requirement: { CustomerRequirementId: false } } };
-
-    const drift = describeColumnDrift(fieldsByQuery, {}, fieldOrder, {}, fieldVisibility);
-
-    expect(drift.dropped).toEqual([{ label: 'CustomerRequirementId', wasRenamed: false, wasHidden: true }]);
+    expect(drift['req-test'].dropped).toEqual([
+      { label: 'Customer ID', side: 'Requirement', wasRenamed: true, wasHidden: false },
+    ]);
   });
 
   test('does not flag ALWAYS_VISIBLE_REFS/EXCLUDED_FIELD_REFS as dropped — deriveFieldList excludes them by design, not because ADO removed them', () => {
@@ -68,7 +99,7 @@ describe('describeColumnDrift', () => {
 
     const drift = describeColumnDrift(fieldsByQuery, {}, fieldOrder, fieldDisplayMapping, {});
 
-    expect(drift.dropped).toEqual([]);
+    expect(drift).toEqual({});
   });
 
   test('reports added columns not present in saved fieldOrder', () => {
@@ -86,11 +117,11 @@ describe('describeColumnDrift', () => {
 
     const drift = describeColumnDrift(fieldsByQuery, {}, fieldOrder, {}, {});
 
-    expect(drift.dropped).toEqual([]);
-    expect(drift.added).toEqual(['Severity']);
+    expect(drift['req-test'].dropped).toEqual([]);
+    expect(drift['req-test'].added).toEqual([{ label: 'Severity', side: 'Requirement' }]);
   });
 
-  test('skips sides with no saved order (nothing to compare yet)', () => {
+  test('skips sides with no saved order (nothing to compare yet) and omits query keys with no drift', () => {
     const fieldsByQuery = {
       'req-test': { Requirement: [{ referenceName: 'System.NodeName', name: 'Node Name' }], 'Test Case': [] },
       'test-req': { Requirement: [], 'Test Case': [] },
@@ -98,21 +129,17 @@ describe('describeColumnDrift', () => {
 
     const drift = describeColumnDrift(fieldsByQuery, {}, {}, {}, {});
 
-    expect(drift).toEqual({ dropped: [], added: [] });
+    expect(drift).toEqual({});
   });
 });
 
 describe('hasColumnDrift', () => {
-  test('false when both lists are empty', () => {
-    expect(hasColumnDrift({ dropped: [], added: [] })).toBe(false);
+  test('false when the drift result has no query keys', () => {
+    expect(hasColumnDrift({})).toBe(false);
   });
 
-  test('true when there are dropped columns', () => {
-    expect(hasColumnDrift({ dropped: [{ label: 'X', wasRenamed: false, wasHidden: false }], added: [] })).toBe(true);
-  });
-
-  test('true when there are added columns', () => {
-    expect(hasColumnDrift({ dropped: [], added: ['Severity'] })).toBe(true);
+  test('true when at least one query key has drift', () => {
+    expect(hasColumnDrift({ 'req-test': { title: 'Req-Test', dropped: [], added: [{ label: 'X', side: 'Requirement' }] } })).toBe(true);
   });
 });
 


### PR DESCRIPTION
Drift entries were flattened into one list, so the user had no way to tell which query (Req-Test vs Test-Req) or side (Requirement vs Test Case) a changed column belonged to — exactly the info needed to diagnose the cross-side/cross-query ghost-data bugs this feature keeps surfacing. describeColumnDrift now returns results grouped by query key, using the query's own title as the heading, with each dropped/ added entry tagged with its side. ColumnDriftToast renders one section per query, separated by a divider.